### PR TITLE
Build hotfixes: Burst-compatible RNG seed + TMP shader typo

### DIFF
--- a/Assets/TextMesh Pro/Shaders/SDFFunctions.hlsl
+++ b/Assets/TextMesh Pro/Shaders/SDFFunctions.hlsl
@@ -22,7 +22,7 @@ float3 GetSpecular(float3 n, float3 l)
 	return _SpecularColor.rgb * spec * _SpecularPower;
 }
 
-void GetSurfaceNormal_float(texture2D atlas, float textureWidth, float textureHeight, float2 uv, bool isFront, out float3 nornmal)
+void GetSurfaceNormal_float(Texture2D atlas, float textureWidth, float textureHeight, float2 uv, bool isFront, out float3 nornmal)
 {
 	float3 delta = float3(1.0 / textureWidth, 1.0 / textureHeight, 0.0);
 

--- a/Assets/_CyberPickle/Code/DOTS/Systems/ProjectileCollisionSystem.cs
+++ b/Assets/_CyberPickle/Code/DOTS/Systems/ProjectileCollisionSystem.cs
@@ -46,9 +46,16 @@ namespace CyberPickle.DOTS.Systems
             state.RequireForUpdate<EnemyTag>();
             state.RequireForUpdate<EndSimulationEntityCommandBufferSystem.Singleton>();
 
-            // Seed from world time + a constant salt so different runs
-            // produce different crit sequences but a single run is stable.
-            _random = new Unity.Mathematics.Random((uint)System.Environment.TickCount | 1u);
+            // Burst-safe seed. System.Environment.TickCount is a managed BCL
+            // property; calling it from a [BurstCompile] context works in the
+            // Editor (Burst falls back to managed execution in some modes)
+            // but CRASHES the player build with an access violation in
+            // ProjectileCollisionSystem.__codegen__OnCreate before the first
+            // frame renders. Random.CreateFromIndex hashes its input so any
+            // uint is safe (including 0). state.GlobalSystemVersion is
+            // available in Burst, non-zero, and varies enough across runs
+            // to give different crit sequences without touching managed APIs.
+            _random = Unity.Mathematics.Random.CreateFromIndex(state.GlobalSystemVersion);
         }
 
         [BurstCompile]


### PR DESCRIPTION
## Summary

Two unrelated build-breaking issues surfaced when running the first player build. Both were authoring or package-level issues (not gameplay code) but blocked all Windows builds.

### 1. ProjectileCollisionSystem.cs — Burst can't call Environment.TickCount

OnCreate was seeding its Unity.Mathematics.Random from System.Environment.TickCount. That's a managed BCL property that requires the .NET runtime to read the system tick counter. The Editor's Burst compiler quietly tolerates this via a managed-fallback path; the player build's Burst is strict. The native code resolved Environment.TickCount to a stale function pointer and crashed inside __codegen__OnCreate during DefaultWorldInitialization — before the first frame rendered.

Fix: Random.CreateFromIndex(state.GlobalSystemVersion). Burst-safe, self-hashes its input, gives per-run variability without touching managed APIs.

### 2. SDFFunctions.hlsl (TMP) — case-sensitive type name

Line 25 declared GetSurfaceNormal_float with parameter "texture2D atlas" (lowercase). Valid HLSL is "Texture2D" (capital T). This made the function fail to parse, which cascaded into "no matching function" errors in 11 different DXR ray-tracing passes of TMP_SDF-HDRP LIT / UNLIT. Forward passes go through a looser compile path and tolerated it; DXR is strict.

Fix: one character. Texture2D.

If TMP gets re-imported, the typo will regress and the same fix re-applies. Worth knowing before another build investigation.

## Test plan
- [x] Editor still runs
- [x] Player build compiles all shader variants
- [x] Player build runs past Unity logo, reaches Boot scene

🤖 Generated with [Claude Code](https://claude.com/claude-code)