### PR TITLE
M7.3: Level-up choice loop + Stage 0 audio scaffold + music design lock

### DIFF
--- a/Assets/_CyberPickle/Code/DOTS/Systems/EnemyDeathSystem.cs
+++ b/Assets/_CyberPickle/Code/DOTS/Systems/EnemyDeathSystem.cs
@@ -34,6 +34,7 @@ using UnityEngine;
 using CyberPickle.DOTS.Bridge;
 using CyberPickle.DOTS.Components;
 using CyberPickle.DOTS.Visual;
+using CyberPickle.Gameplay.Audio;
 using CyberPickle.Gameplay.RunState;
 using URandom = UnityEngine.Random;
 
@@ -103,6 +104,17 @@ namespace CyberPickle.DOTS.Systems
             {
                 for (int i = 0; i < dyingEntities.Length; i++)
                     RunStatsTracker.Instance.RecordEnemyKilled();
+            }
+
+            // Music event broadcast — one per death. EnemyDeathSystem is
+            // SystemBase (managed), so calling MusicEventBus.Fire from here
+            // is safe; ISystem / Burst systems would need an event-entity
+            // bridge instead. Stage 0: Debug.Log. Stage 2 (Wwise): per-kill
+            // particle / stinger trigger; aggregated kills drive the
+            // CombatIntensity RTPC.
+            for (int i = 0; i < dyingEntities.Length; i++)
+            {
+                MusicEventBus.Fire(MusicEvent.EnemyDeath);
             }
 
             for (int i = 0; i < dyingEntities.Length; i++)

--- a/Assets/_CyberPickle/Code/Gameplay/Audio.meta
+++ b/Assets/_CyberPickle/Code/Gameplay/Audio.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f99e7128019a5cd4aaa83c49ad05ca30
+guid: 41ed6134ed010c244ab8c59eeaf7c947
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/_CyberPickle/Code/Gameplay/Audio/MusicConductor.cs
+++ b/Assets/_CyberPickle/Code/Gameplay/Audio/MusicConductor.cs
@@ -1,0 +1,199 @@
+// File: Assets/_CyberPickle/Code/Gameplay/Audio/MusicConductor.cs
+// Namespace: CyberPickle.Gameplay.Audio
+//
+// Single source of musical timing for the run. Owns the master tempo and
+// emits OnBeat / OnBar / OnSubdivision events that gameplay systems
+// subscribe to for beat-quantized firing, UI pulsing, particle sync, etc.
+//
+// Stage 0 (today): naive Time.time-based clock. Sufficient for visual
+// pulsing, weapon-firing intent buffering, and validating the architecture.
+// Frame-rate dips can drop subdivisions if a frame >1 grid unit; fine for
+// stub work, not for shipping.
+//
+// Stage 2 (M9 Wwise): replace the Update loop with Wwise music callbacks
+// (AK_MusicSyncBeat / AK_MusicSyncGrid). Sample-accurate to the audio
+// thread. Public API stays identical — subscribers don't need to know
+// which clock is driving the events.
+//
+// Scene-bound: belongs in Game.unity. Other scenes don't need it; menus
+// don't have a tempo concept yet (might add later for menu-music sync).
+
+using System;
+using UnityEngine;
+using CyberPickle.Core.Management;
+using CyberPickle.Gameplay.RunState;
+
+namespace CyberPickle.Gameplay.Audio
+{
+    [DisallowMultipleComponent]
+    public class MusicConductor : Manager<MusicConductor>
+    {
+        // Scene-bound: dies with the Game scene. Same lifecycle as
+        // RunStateManager / RunStatsTracker.
+        protected override bool PersistAcrossScenes => false;
+
+        [Header("Tempo")]
+        [Tooltip("Master tempo in beats per minute. Default 128 — French-electro / cyberpunk standard. See GDD §3.5.2.")]
+        [SerializeField, Range(60f, 200f)] private float bpm = 128f;
+
+        [Tooltip("Subdivisions per beat. 4 = 16th-note grid (fast weapons), 2 = 8th-note grid (medium), 1 = quarter (slow). Most weapons will quantize to 16ths.")]
+        [SerializeField, Range(1, 8)] private int subdivisionsPerBeat = 4;
+
+        [Header("Diagnostics")]
+        [Tooltip("Log each beat / bar to the console. Off by default — chatty.")]
+        [SerializeField] private bool verbose;
+
+        // ─── Public state ─────────────────────────────────────────────────
+
+        public float BPM => bpm;
+        public int   SubdivisionsPerBeat => subdivisionsPerBeat;
+
+        /// <summary>Seconds per beat at the current BPM. Useful for tweens / wait times that need to match the grid.</summary>
+        public float SecondsPerBeat => 60f / bpm;
+
+        /// <summary>Seconds per subdivision. shortest grid unit.</summary>
+        public float SecondsPerSubdivision => 60f / (bpm * subdivisionsPerBeat);
+
+        /// <summary>Number of beats fired since the most recent RunStart. 0 before the first beat fires.</summary>
+        public int CurrentBeat { get; private set; }
+
+        /// <summary>Number of subdivisions fired since the most recent RunStart.</summary>
+        public int CurrentSubdivision { get; private set; }
+
+        /// <summary>Bar number (4 beats per bar in 4/4). 0-indexed.</summary>
+        public int CurrentBar => CurrentBeat / 4;
+
+        // ─── Public events ────────────────────────────────────────────────
+
+        /// <summary>Fires every beat. Subscribe for quarter-note locked behavior (kicks, slow weapons).</summary>
+        public event Action OnBeat;
+
+        /// <summary>Fires every bar (every 4 beats in 4/4). Subscribe for phrase-level events (transitions, big swells).</summary>
+        public event Action OnBar;
+
+        /// <summary>Fires every subdivision (16th note by default). Highest-resolution grid for fast weapons + UI sync.</summary>
+        public event Action OnSubdivision;
+
+        // ─── Internal clock state ─────────────────────────────────────────
+
+        private float _runStartTime;
+        private int _lastSubdivisionFired = -1;
+        private int _lastBeatFired = -1;
+        private int _lastBarFired = -1;
+
+        // ─── Manager lifecycle ────────────────────────────────────────────
+
+        protected override void OnManagerEnabled()
+        {
+            base.OnManagerEnabled();
+            // Subscribe to the bus for RunStart so we can reset our clock to
+            // align beat 0 with the moment combat begins.
+            MusicEventBus.OnEvent += HandleMusicEvent;
+
+            // Also align with RunStateManager directly: TransitionTo(Running)
+            // is the run's actual start, regardless of who fires it. Belt and
+            // suspenders — the bus handles producer-driven RunStart while the
+            // direct subscription handles RunStateManager initialization.
+            if (RunStateManager.Instance != null)
+            {
+                RunStateManager.Instance.OnPhaseChanged += HandleRunPhaseChanged;
+                if (RunStateManager.Instance.IsRunning) ResetClock();
+            }
+        }
+
+        protected override void OnManagerDisabled()
+        {
+            base.OnManagerDisabled();
+            MusicEventBus.OnEvent -= HandleMusicEvent;
+            if (RunStateManager.Instance != null)
+                RunStateManager.Instance.OnPhaseChanged -= HandleRunPhaseChanged;
+        }
+
+        // ─── Event handlers ───────────────────────────────────────────────
+
+        private void HandleMusicEvent(MusicEvent type, object _)
+        {
+            if (type == MusicEvent.RunStart) ResetClock();
+        }
+
+        private void HandleRunPhaseChanged(RunStatePhase phase)
+        {
+            // Reset on the run's first entry to Running; PRESERVE the clock
+            // through LevelUpPaused / Paused so the music keeps phase across
+            // the level-up screen (a card pick that lands "on the beat" must
+            // pick the same beat that was about to play).
+            if (phase == RunStatePhase.Running && CurrentSubdivision == 0)
+            {
+                ResetClock();
+            }
+        }
+
+        private void ResetClock()
+        {
+            _runStartTime = Time.time;
+            _lastSubdivisionFired = -1;
+            _lastBeatFired = -1;
+            _lastBarFired = -1;
+            CurrentSubdivision = 0;
+            CurrentBeat = 0;
+            if (verbose) Debug.Log($"[MusicConductor] Clock reset. BPM={bpm}, subdivisions/beat={subdivisionsPerBeat}.");
+        }
+
+        // ─── Frame loop ───────────────────────────────────────────────────
+
+        private void Update()
+        {
+            // Don't tick during paused phases — Time.time still advances but
+            // the run is effectively frozen and music should pause with it.
+            // (Stage 2 with Wwise will tick from the audio callback regardless,
+            // since Wwise has its own clock; revisit then.)
+            var rsm = RunStateManager.Instance;
+            if (rsm != null && !rsm.IsRunning) return;
+
+            float elapsed = Time.time - _runStartTime;
+            int subdivision = Mathf.FloorToInt(elapsed / SecondsPerSubdivision);
+
+            // Catch up across multiple subdivisions if a frame was long
+            // enough to skip one. We fire each missed event once so weapon
+            // patterns don't desync from the grid on hitches.
+            while (_lastSubdivisionFired < subdivision)
+            {
+                _lastSubdivisionFired++;
+                CurrentSubdivision = _lastSubdivisionFired;
+                OnSubdivision?.Invoke();
+
+                int beat = CurrentSubdivision / subdivisionsPerBeat;
+                if (beat != _lastBeatFired)
+                {
+                    _lastBeatFired = beat;
+                    CurrentBeat = beat;
+                    if (verbose) Debug.Log($"[MusicConductor] Beat {beat}");
+                    OnBeat?.Invoke();
+
+                    int bar = beat / 4;
+                    if (bar != _lastBarFired)
+                    {
+                        _lastBarFired = bar;
+                        if (verbose) Debug.Log($"[MusicConductor] Bar {bar}");
+                        OnBar?.Invoke();
+                    }
+                }
+            }
+        }
+
+        // ─── Quantization helper (Day 1 baseline; extended in M7.3) ─────
+
+        /// <summary>
+        /// Returns the seconds-from-now of the next subdivision boundary.
+        /// Caller can use this to delay firing until the grid lands. Stage 0
+        /// implementation; Stage 2 routes through Wwise's tempo timeline.
+        /// </summary>
+        public float TimeUntilNextSubdivision()
+        {
+            float elapsed = Time.time - _runStartTime;
+            float secs = SecondsPerSubdivision;
+            float intoCurrent = elapsed % secs;
+            return secs - intoCurrent;
+        }
+    }
+}

--- a/Assets/_CyberPickle/Code/Gameplay/Audio/MusicConductor.cs
+++ b/Assets/_CyberPickle/Code/Gameplay/Audio/MusicConductor.cs
@@ -43,6 +43,9 @@ namespace CyberPickle.Gameplay.Audio
         [Tooltip("Log each beat / bar to the console. Off by default — chatty.")]
         [SerializeField] private bool verbose;
 
+        [Tooltip("Mirror MusicEventBus.VerboseLogging — when ON, every Fire() call logs (RunStart, WeaponFire, EnemyDeath, PlayerHit, etc.). Useful for confirming producers are wired. WARNING: WeaponFire alone can spam 30+/sec in combat. Toggle off when not actively diagnosing.")]
+        [SerializeField] private bool verboseEventBus;
+
         // ─── Public state ─────────────────────────────────────────────────
 
         public float BPM => bpm;
@@ -86,6 +89,10 @@ namespace CyberPickle.Gameplay.Audio
         protected override void OnManagerEnabled()
         {
             base.OnManagerEnabled();
+            // Apply inspector toggle to the static bus flag. Editor-friendly:
+            // the user can flip the bool in the inspector mid-Play and changes
+            // take effect immediately via OnValidate (below).
+            MusicEventBus.VerboseLogging = verboseEventBus;
             // Subscribe to the bus for RunStart so we can reset our clock to
             // align beat 0 with the moment combat begins.
             MusicEventBus.OnEvent += HandleMusicEvent;
@@ -127,6 +134,15 @@ namespace CyberPickle.Gameplay.Audio
                 ResetClock();
             }
         }
+
+#if UNITY_EDITOR
+        private void OnValidate()
+        {
+            // Apply inspector tweaks live during Play so the user can toggle
+            // verbose logging mid-session without restarting.
+            MusicEventBus.VerboseLogging = verboseEventBus;
+        }
+#endif
 
         private void ResetClock()
         {

--- a/Assets/_CyberPickle/Code/Gameplay/Audio/MusicConductor.cs.meta
+++ b/Assets/_CyberPickle/Code/Gameplay/Audio/MusicConductor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1074df45eeb9b074c8cf48b96e9df101

--- a/Assets/_CyberPickle/Code/Gameplay/Audio/MusicEvent.cs
+++ b/Assets/_CyberPickle/Code/Gameplay/Audio/MusicEvent.cs
@@ -1,0 +1,72 @@
+// File: Assets/_CyberPickle/Code/Gameplay/Audio/MusicEvent.cs
+// Namespace: CyberPickle.Gameplay.Audio
+//
+// Canonical enumeration of every gameplay event that the audio system
+// might react to. Producers (gameplay code) fire these via
+// MusicEventBus.Fire(...). Consumers (Stage 0: Debug.Log; Stage 2+: Wwise
+// event posts; the conductor; the damage feedback system; UI sounds)
+// subscribe to MusicEventBus.OnEvent.
+//
+// Why a single enum instead of N separate C# events: one decoupled bus
+// means we can add new producers/consumers without rewiring half the
+// codebase, and the Stage 2 Wwise hook is a single mapping table from
+// MusicEvent -> Ak event name.
+//
+// Byte-typed for serialization stability (cards / save data may reference
+// these by id without binding to enum order). Add new entries at the end;
+// never reorder.
+//
+// Payload convention: each event documents what payload type Fire() expects
+// (or null). Day-1 stub uses object boxing; future iterations replace with
+// typed Fire<T> overloads to avoid GC.
+
+namespace CyberPickle.Gameplay.Audio
+{
+    public enum MusicEvent : byte
+    {
+        // ─── Run lifecycle ───────────────────────────────────────────────
+        // payload: null
+        RunStart        = 0,
+        // payload: null
+        RunEnd          = 1,
+        // payload: RunStatePhase (the new phase)
+        PhaseChanged    = 2,
+
+        // ─── Combat — outgoing ───────────────────────────────────────────
+        // payload: WeaponFireData? or weapon-id string (TBD when typed structs land)
+        WeaponFire      = 10,
+        // payload: damage value (float) — broadly mapped, drives RTPCs not notes
+        EnemyHit        = 11,
+        // payload: damage value (float) on a crit
+        Crit            = 12,
+        // payload: enemy-id or null
+        EnemyDeath      = 13,
+
+        // ─── Combat — incoming ───────────────────────────────────────────
+        // payload: damage value (float)
+        PlayerHit       = 20,
+        PlayerHealed    = 21,
+
+        // ─── Progression ─────────────────────────────────────────────────
+        // payload: new level (int)
+        LevelUp         = 30,
+        // payload: card-id (string) — fires when the user hovers a card
+        CardHover       = 31,
+        // payload: card-id (string) — fires when the user picks a card
+        CardPicked      = 32,
+        CardBanished    = 33,
+        CardRerolled    = 34,
+
+        // ─── Bosses ──────────────────────────────────────────────────────
+        BossSpawn       = 40,
+        // payload: phase index (int) — 1, 2, 3 as boss HP crosses thresholds
+        BossPhase       = 41,
+        BossDefeated    = 42,
+
+        // ─── UI (non-musical, but routed for audio mixing) ──────────────
+        ButtonHover     = 50,
+        ButtonClick     = 51,
+        MenuOpen        = 52,
+        MenuClose       = 53,
+    }
+}

--- a/Assets/_CyberPickle/Code/Gameplay/Audio/MusicEvent.cs.meta
+++ b/Assets/_CyberPickle/Code/Gameplay/Audio/MusicEvent.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bfa35123573110f4bbb497a3af36c217

--- a/Assets/_CyberPickle/Code/Gameplay/Audio/MusicEventBus.cs
+++ b/Assets/_CyberPickle/Code/Gameplay/Audio/MusicEventBus.cs
@@ -1,0 +1,88 @@
+// File: Assets/_CyberPickle/Code/Gameplay/Audio/MusicEventBus.cs
+// Namespace: CyberPickle.Gameplay.Audio
+//
+// Static fan-out for gameplay → audio events. Producers call Fire(); any
+// number of consumers subscribe to OnEvent. Stage 0 (today): Debug.Log
+// when verbose logging is on. Stage 2 (M9 Wwise integration): a single
+// listener maps each MusicEvent to an Ak event post.
+//
+// Why static, not Manager<T>: the bus has no per-scene state and no
+// inspector-bindings. It's a process-global pure dispatcher. Keeping it
+// static side-steps Manager<T>'s Awake-ordering concerns and means callers
+// don't have to null-check an Instance during editor recompiles.
+//
+// Threading: Unity main thread only. Burst-compiled ECS systems CANNOT
+// call this directly — they must accumulate events into an
+// IComponentData / NativeQueue and have a managed bridge drain them on
+// the main thread. See EnemyDeathBridge (TBD) for the pattern.
+//
+// Payload alloc note: the `object` parameter boxes value-typed payloads.
+// For the Day-1 stub this is fine; the firing rates are bounded and we
+// just Debug.Log. When Stage 2 lands, replace with typed Fire<T>(MusicEvent, T)
+// overloads constrained to struct, plus a SetPayloadTo / GetPayloadFrom
+// pattern for the Wwise listener.
+
+using System;
+using UnityEngine;
+
+namespace CyberPickle.Gameplay.Audio
+{
+    public static class MusicEventBus
+    {
+        /// <summary>
+        /// Subscribe to receive every event fired through the bus. Listeners
+        /// MUST be written defensively (handle null payloads, unexpected
+        /// types). Subscribe in OnEnable, unsubscribe in OnDisable.
+        /// </summary>
+        public static event Action<MusicEvent, object> OnEvent;
+
+        /// <summary>
+        /// When true, every Fire() emits a Debug.Log. Off by default to
+        /// avoid console flood in combat (WeaponFire alone can fire 30+/sec).
+        /// Toggle on for diagnostic sessions or when wiring a new producer.
+        /// </summary>
+        public static bool VerboseLogging;
+
+        /// <summary>
+        /// Dispatch a music event. Payload semantics are per-event and
+        /// documented on the MusicEvent enum. Pass null when not applicable.
+        /// </summary>
+        public static void Fire(MusicEvent type, object payload = null)
+        {
+            if (VerboseLogging)
+            {
+                if (payload != null)
+                    Debug.Log($"[MusicEventBus] {type}  payload={payload}");
+                else
+                    Debug.Log($"[MusicEventBus] {type}");
+            }
+
+            // Defensive: a buggy listener mustn't take down other listeners.
+            // We swallow per-listener exceptions and log them so combat keeps
+            // running even if (e.g.) a UI controller is mid-destruction.
+            var handlers = OnEvent;
+            if (handlers == null) return;
+
+            foreach (var h in handlers.GetInvocationList())
+            {
+                try
+                {
+                    ((Action<MusicEvent, object>)h)(type, payload);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"[MusicEventBus] Listener threw on {type}: {ex.Message}\n{ex.StackTrace}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Clear all subscribers. Editor-only utility for recovering from
+        /// stuck domain-reload state. Don't call from gameplay code.
+        /// </summary>
+        public static void ClearAllListeners()
+        {
+            OnEvent = null;
+        }
+    }
+}

--- a/Assets/_CyberPickle/Code/Gameplay/Audio/MusicEventBus.cs.meta
+++ b/Assets/_CyberPickle/Code/Gameplay/Audio/MusicEventBus.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 806b652e683358e4096ff9c1dc368f18

--- a/Assets/_CyberPickle/Code/Gameplay/Player/PlayerHealth.cs
+++ b/Assets/_CyberPickle/Code/Gameplay/Player/PlayerHealth.cs
@@ -29,6 +29,7 @@
 
 using System;
 using UnityEngine;
+using CyberPickle.Gameplay.Audio;
 using CyberPickle.Gameplay.Stats;
 
 namespace CyberPickle.Gameplay.Player
@@ -148,11 +149,18 @@ namespace CyberPickle.Gameplay.Player
             OnDamageTaken?.Invoke();
             OnHealthChanged?.Invoke(_currentHealth, MaxHealth);
 
+            // Broadcast to the audio bus. Damage feedback systems and the
+            // music conductor (low-HP heartbeat, music ducking) listen here.
+            MusicEventBus.Fire(MusicEvent.PlayerHit, reduced);
+
             if (_currentHealth <= 0f)
             {
                 _isAlive = false;
                 if (verbose) Debug.Log("[PlayerHealth] Player died.");
                 OnPlayerDied?.Invoke();
+                // RunEnd is also fired by RunStateManager when phase becomes
+                // GameOver; firing it here too means death-music can react
+                // immediately, before the run-state coroutine cycles.
             }
         }
 
@@ -163,7 +171,12 @@ namespace CyberPickle.Gameplay.Player
             float prev = _currentHealth;
             _currentHealth = Mathf.Min(MaxHealth, _currentHealth + amount);
             if (!Mathf.Approximately(prev, _currentHealth))
+            {
                 OnHealthChanged?.Invoke(_currentHealth, MaxHealth);
+                // Heal events drive subtle audio cues (lifesteal sub-bass,
+                // regen high-frequency shimmer per GDD §3.12.6).
+                MusicEventBus.Fire(MusicEvent.PlayerHealed, _currentHealth - prev);
+            }
         }
 
         /// <summary>

--- a/Assets/_CyberPickle/Code/Gameplay/Player/PlayerXPBridge.cs
+++ b/Assets/_CyberPickle/Code/Gameplay/Player/PlayerXPBridge.cs
@@ -19,6 +19,7 @@ using System;
 using Unity.Entities;
 using UnityEngine;
 using CyberPickle.DOTS.Components;
+using CyberPickle.Gameplay.Audio;
 
 namespace CyberPickle.Gameplay.Player
 {
@@ -136,6 +137,10 @@ namespace CyberPickle.Gameplay.Player
                 changed = true;
 
                 OnLevelUp?.Invoke(xp.CurrentLevel);
+                // Broadcast onto the audio bus too — LevelUpCoordinator
+                // listens here to drive the choice screen, and future
+                // music systems use this for level-up stingers.
+                MusicEventBus.Fire(MusicEvent.LevelUp, xp.CurrentLevel);
             }
 
             if (changed)

--- a/Assets/_CyberPickle/Code/Gameplay/Progression.meta
+++ b/Assets/_CyberPickle/Code/Gameplay/Progression.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 296b0da239cfefd46afb82c8f00ae5e3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_CyberPickle/Code/Gameplay/Progression/LevelUpCoordinator.cs
+++ b/Assets/_CyberPickle/Code/Gameplay/Progression/LevelUpCoordinator.cs
@@ -1,0 +1,228 @@
+// File: Assets/_CyberPickle/Code/Gameplay/Progression/LevelUpCoordinator.cs
+// Namespace: CyberPickle.Gameplay.Progression
+//
+// Orchestrates the level-up flow:
+//
+//   1. Subscribes to PlayerXPBridge.OnLevelUp (managed C# event).
+//   2. On level-up: transitions RunStateManager → LevelUpPaused (per
+//      GDD §3.11, this freezes Time.timeScale. Future M7.3-day-5 polish
+//      replaces full pause with timeScale=0.05 slow-mo).
+//   3. Draws N cards from the active UpgradePoolSO (filtered by banished
+//      + prerequisite, weighted by Luck).
+//   4. Raises OnCardsDrawn for the UI (LevelUpScreenController, M7.3 day 3-4).
+//   5. Awaits a card pick via NotifyCardPicked() (called by the UI).
+//   6. Applies the picked card's modifiers to PlayerStats, records the
+//      pick in OwnedCardIds for prerequisite tracking, fires
+//      MusicEvent.CardPicked.
+//   7. Transitions RunStateManager back to Running.
+//
+// If multiple level-ups stack (XP gem cluster pushed past two thresholds
+// in one frame), the queue handles them in FIFO order — one card screen
+// per level, no batching. This matches Vampire Survivors' UX.
+//
+// Lifecycle: drop on a [LevelUpCoordinator] empty GameObject in Game.unity.
+// Inspector wiring: assign the active UpgradePoolSO + the PlayerStats and
+// PlayerXPBridge components on the player root. Coordinator finds the
+// SpawnedPlayer at run-start by listening to GameSceneBootstrap (deferred —
+// for M7.3 day 2 we just inspector-bind directly; auto-discovery is
+// day-5 polish).
+
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using CyberPickle.Gameplay.Audio;
+using CyberPickle.Gameplay.Player;
+using CyberPickle.Gameplay.RunState;
+using CyberPickle.Gameplay.Stats;
+
+namespace CyberPickle.Gameplay.Progression
+{
+    [DisallowMultipleComponent]
+    public class LevelUpCoordinator : MonoBehaviour
+    {
+        [Header("Pool")]
+        [Tooltip("The card pool this run draws from. Future: per-character pools live on CharacterData; for M7.3 day-2 this is set per scene.")]
+        [SerializeField] private UpgradePoolSO pool;
+
+        [Header("Player Refs")]
+        [Tooltip("Player's PlayerStats component. Filled by GameSceneBootstrap when the player spawns (auto-discovered if left empty at Awake).")]
+        [SerializeField] private PlayerStats playerStats;
+
+        [Tooltip("Player's PlayerXPBridge component. Source of OnLevelUp events.")]
+        [SerializeField] private PlayerXPBridge xpBridge;
+
+        [Header("Draw Settings")]
+        [Tooltip("How many cards to show on each level-up. Default 3 (Vampire Survivors / Survivor.io standard).")]
+        [Min(1)] [SerializeField] private int cardsPerOffer = 3;
+
+        [Header("Diagnostics")]
+        [Tooltip("Log each level-up + card pick to the console.")]
+        [SerializeField] private bool verbose = true;
+
+        // ─── Public events for the UI layer ───────────────────────────────
+
+        /// <summary>Fires when the coordinator has drawn cards and the UI should display them. Argument is the cards to show.</summary>
+        public event Action<IReadOnlyList<UpgradeCardSO>> OnCardsDrawn;
+
+        /// <summary>Fires after the picked card's modifiers have been applied. Argument is the picked card. Useful for animation hooks.</summary>
+        public event Action<UpgradeCardSO> OnCardApplied;
+
+        // ─── Public API for the UI to call back into ──────────────────────
+
+        /// <summary>
+        /// Called by the UI when the player picks a card. Applies modifiers,
+        /// records ownership, resumes the run.
+        /// </summary>
+        public void NotifyCardPicked(UpgradeCardSO card)
+        {
+            if (card == null)
+            {
+                Debug.LogError("[LevelUpCoordinator] NotifyCardPicked called with null card.");
+                ResumeRun();
+                return;
+            }
+
+            if (playerStats == null)
+            {
+                Debug.LogError("[LevelUpCoordinator] No playerStats reference — cannot apply card. Resuming anyway.");
+                ResumeRun();
+                return;
+            }
+
+            int applied = card.ApplyTo(playerStats);
+            _ownedCardIds.Add(card.cardId);
+            if (verbose)
+                Debug.Log($"[LevelUpCoordinator] Applied '{card.cardId}' ({applied} modifiers). Stats now refreshed.");
+
+            MusicEventBus.Fire(MusicEvent.CardPicked, card.cardId);
+            OnCardApplied?.Invoke(card);
+
+            ResumeRun();
+            ProcessNextPendingLevelUp();
+        }
+
+        /// <summary>
+        /// Called by the UI when the player banishes a card from the pool.
+        /// The card stays in this offer (the player still has to pick from
+        /// the remaining cards) but won't appear in future draws this run.
+        /// </summary>
+        public void NotifyCardBanished(UpgradeCardSO card)
+        {
+            if (card == null) return;
+            _banishedCardIds.Add(card.cardId);
+            MusicEventBus.Fire(MusicEvent.CardBanished, card.cardId);
+            if (verbose) Debug.Log($"[LevelUpCoordinator] Banished '{card.cardId}'.");
+        }
+
+        /// <summary>Diagnostic accessor. UI uses to grey-out already-owned cards if relevant.</summary>
+        public IReadOnlyCollection<string> OwnedCardIds => _ownedCardIds;
+
+        /// <summary>Diagnostic accessor. UI uses to grey-out banished cards.</summary>
+        public IReadOnlyCollection<string> BanishedCardIds => _banishedCardIds;
+
+        // ─── Internal state ───────────────────────────────────────────────
+
+        private readonly HashSet<string> _ownedCardIds = new HashSet<string>();
+        private readonly HashSet<string> _banishedCardIds = new HashSet<string>();
+        private readonly Queue<int> _pendingLevels = new Queue<int>();
+        private bool _screenActive;
+
+        // ─── Lifecycle ────────────────────────────────────────────────────
+
+        private void OnEnable()
+        {
+            // Inspector binding is the primary path; auto-discovery is a
+            // safety net for direct-Play in the editor without a full Boot
+            // scene flow.
+            TryAutoDiscoverPlayerRefs();
+
+            if (xpBridge != null)
+            {
+                xpBridge.OnLevelUp += HandleLevelUp;
+            }
+            else
+            {
+                Debug.LogWarning("[LevelUpCoordinator] No PlayerXPBridge — coordinator will not receive level-up events.");
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (xpBridge != null)
+                xpBridge.OnLevelUp -= HandleLevelUp;
+        }
+
+        private void TryAutoDiscoverPlayerRefs()
+        {
+            if (playerStats == null)
+                playerStats = FindFirstObjectByType<PlayerStats>();
+            if (xpBridge == null)
+                xpBridge = FindFirstObjectByType<PlayerXPBridge>();
+        }
+
+        // ─── Level-up flow ────────────────────────────────────────────────
+
+        private void HandleLevelUp(int newLevel)
+        {
+            _pendingLevels.Enqueue(newLevel);
+            if (verbose)
+                Debug.Log($"[LevelUpCoordinator] Level-up queued: {newLevel}. Queue depth = {_pendingLevels.Count}.");
+
+            // If the screen isn't currently up, start processing. If it IS
+            // up, this level-up is queued and processed when the current
+            // pick completes.
+            if (!_screenActive)
+                ProcessNextPendingLevelUp();
+        }
+
+        private void ProcessNextPendingLevelUp()
+        {
+            if (_pendingLevels.Count == 0) return;
+            int level = _pendingLevels.Dequeue();
+            ShowLevelUpScreen(level);
+        }
+
+        private void ShowLevelUpScreen(int newLevel)
+        {
+            if (pool == null)
+            {
+                Debug.LogError("[LevelUpCoordinator] No UpgradePoolSO assigned. Cannot draw cards.");
+                return;
+            }
+
+            // Pause the run.
+            if (RunStateManager.Instance != null)
+                RunStateManager.Instance.TransitionTo(RunStatePhase.LevelUpPaused);
+
+            // Draw cards.
+            float luck = playerStats != null ? playerStats.Get(PlayerStatType.Luck) : 0f;
+            var cards = pool.DrawCards(cardsPerOffer, luck, _banishedCardIds, _ownedCardIds);
+
+            if (cards.Count == 0)
+            {
+                Debug.LogWarning("[LevelUpCoordinator] Pool returned 0 eligible cards. Resuming run with no offer.");
+                ResumeRun();
+                ProcessNextPendingLevelUp();
+                return;
+            }
+
+            if (verbose)
+            {
+                string cardList = string.Join(", ", cards.ConvertAll(c => $"{c.cardId}({c.rarity})"));
+                Debug.Log($"[LevelUpCoordinator] Drew {cards.Count} cards for level {newLevel}: {cardList}");
+            }
+
+            _screenActive = true;
+            OnCardsDrawn?.Invoke(cards);
+        }
+
+        private void ResumeRun()
+        {
+            _screenActive = false;
+            if (RunStateManager.Instance != null && RunStateManager.Instance.CurrentPhase == RunStatePhase.LevelUpPaused)
+            {
+                RunStateManager.Instance.TransitionTo(RunStatePhase.Running);
+            }
+        }
+    }
+}

--- a/Assets/_CyberPickle/Code/Gameplay/Progression/LevelUpCoordinator.cs
+++ b/Assets/_CyberPickle/Code/Gameplay/Progression/LevelUpCoordinator.cs
@@ -3,13 +3,20 @@
 //
 // Orchestrates the level-up flow:
 //
-//   1. Subscribes to PlayerXPBridge.OnLevelUp (managed C# event).
+//   1. Subscribes to MusicEventBus.OnEvent and filters for MusicEvent.LevelUp.
+//      (Originally tried PlayerXPBridge.OnLevelUp directly, but that race-
+//      conditioned with the player-spawn order: LevelUpCoordinator's OnEnable
+//      fires at scene-load, before GameSceneBootstrap.Start spawns the player,
+//      so FindFirstObjectByType<PlayerXPBridge>() returned null and the
+//      coordinator silently never subscribed. The MusicEventBus is a static
+//      class — process-global, alive from assembly load — so bus
+//      subscriptions don't care about scene-load timing.)
 //   2. On level-up: transitions RunStateManager → LevelUpPaused (per
 //      GDD §3.11, this freezes Time.timeScale. Future M7.3-day-5 polish
 //      replaces full pause with timeScale=0.05 slow-mo).
 //   3. Draws N cards from the active UpgradePoolSO (filtered by banished
 //      + prerequisite, weighted by Luck).
-//   4. Raises OnCardsDrawn for the UI (LevelUpScreenController, M7.3 day 3-4).
+//   4. Raises OnCardsDrawn for the UI (LevelUpScreenController).
 //   5. Awaits a card pick via NotifyCardPicked() (called by the UI).
 //   6. Applies the picked card's modifiers to PlayerStats, records the
 //      pick in OwnedCardIds for prerequisite tracking, fires
@@ -21,17 +28,14 @@
 // per level, no batching. This matches Vampire Survivors' UX.
 //
 // Lifecycle: drop on a [LevelUpCoordinator] empty GameObject in Game.unity.
-// Inspector wiring: assign the active UpgradePoolSO + the PlayerStats and
-// PlayerXPBridge components on the player root. Coordinator finds the
-// SpawnedPlayer at run-start by listening to GameSceneBootstrap (deferred —
-// for M7.3 day 2 we just inspector-bind directly; auto-discovery is
-// day-5 polish).
+// Inspector wiring: assign the active UpgradePoolSO. PlayerStats is
+// lazy-discovered the first time it's needed (which is at card-pick time,
+// by which point the player has been spawned for sure).
 
 using System;
 using System.Collections.Generic;
 using UnityEngine;
 using CyberPickle.Gameplay.Audio;
-using CyberPickle.Gameplay.Player;
 using CyberPickle.Gameplay.RunState;
 using CyberPickle.Gameplay.Stats;
 
@@ -45,11 +49,8 @@ namespace CyberPickle.Gameplay.Progression
         [SerializeField] private UpgradePoolSO pool;
 
         [Header("Player Refs")]
-        [Tooltip("Player's PlayerStats component. Filled by GameSceneBootstrap when the player spawns (auto-discovered if left empty at Awake).")]
+        [Tooltip("Player's PlayerStats component. Lazy-discovered at first level-up (the player isn't spawned yet at scene-load time, so we can't bind here in OnEnable). Inspector slot left available in case you want to wire explicitly for testing.")]
         [SerializeField] private PlayerStats playerStats;
-
-        [Tooltip("Player's PlayerXPBridge component. Source of OnLevelUp events.")]
-        [SerializeField] private PlayerXPBridge xpBridge;
 
         [Header("Draw Settings")]
         [Tooltip("How many cards to show on each level-up. Default 3 (Vampire Survivors / Survivor.io standard).")]
@@ -82,7 +83,7 @@ namespace CyberPickle.Gameplay.Progression
                 return;
             }
 
-            if (playerStats == null)
+            if (!EnsurePlayerStats())
             {
                 Debug.LogError("[LevelUpCoordinator] No playerStats reference — cannot apply card. Resuming anyway.");
                 ResumeRun();
@@ -131,38 +132,96 @@ namespace CyberPickle.Gameplay.Progression
 
         private void OnEnable()
         {
-            // Inspector binding is the primary path; auto-discovery is a
-            // safety net for direct-Play in the editor without a full Boot
-            // scene flow.
-            TryAutoDiscoverPlayerRefs();
-
-            if (xpBridge != null)
-            {
-                xpBridge.OnLevelUp += HandleLevelUp;
-            }
-            else
-            {
-                Debug.LogWarning("[LevelUpCoordinator] No PlayerXPBridge — coordinator will not receive level-up events.");
-            }
+            // Subscribe to the process-global music bus. This is the ONLY
+            // listener we wire here because the bus is the only source we
+            // can rely on to be alive at OnEnable time — components like
+            // PlayerXPBridge don't exist yet (the player is spawned by
+            // GameSceneBootstrap.Start, AFTER all OnEnables). PlayerStats
+            // is lazy-discovered when needed (see EnsurePlayerStats).
+            MusicEventBus.OnEvent += HandleMusicEvent;
         }
 
         private void OnDisable()
         {
-            if (xpBridge != null)
-                xpBridge.OnLevelUp -= HandleLevelUp;
+            MusicEventBus.OnEvent -= HandleMusicEvent;
         }
 
-        private void TryAutoDiscoverPlayerRefs()
+        private void HandleMusicEvent(MusicEvent type, object payload)
+        {
+            switch (type)
+            {
+                case MusicEvent.RunStart:
+                    // The player is spawned and PlayerStats is initialized BEFORE
+                    // RunStateManager.TransitionTo(Running) fires this event (see
+                    // GameSceneBootstrap.SpawnSelectedCharacter — InitializePlayerStats
+                    // is called before TransitionTo). So by the time we land here,
+                    // PlayerStats exists and is ready to read.
+                    //
+                    // Doing the find here means level-up events later are
+                    // free of any FindFirstObjectByType cost. The find is O(n)
+                    // in scene size — fine to pay once per run, expensive to
+                    // repeat per level-up.
+                    CachePlayerRefs();
+                    ResetRunScopedState();
+                    break;
+
+                case MusicEvent.LevelUp:
+                    int newLevel = payload is int l ? l : 0;
+                    EnqueueLevelUp(newLevel);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// One-time per-run cache of the player components. Honors any
+        /// inspector-wired reference (don't overwrite if the user pre-bound).
+        /// Logs an error if PlayerStats is somehow still missing — would
+        /// indicate the player failed to spawn or the bootstrap mis-ordered
+        /// stat init vs. RunStateManager transition.
+        /// </summary>
+        private void CachePlayerRefs()
         {
             if (playerStats == null)
                 playerStats = FindFirstObjectByType<PlayerStats>();
-            if (xpBridge == null)
-                xpBridge = FindFirstObjectByType<PlayerXPBridge>();
+
+            if (playerStats == null)
+                Debug.LogError("[LevelUpCoordinator] CachePlayerRefs: no PlayerStats found at RunStart. Player did not spawn correctly.");
+            else if (verbose)
+                Debug.Log($"[LevelUpCoordinator] Cached PlayerStats on '{playerStats.name}' at RunStart.");
+        }
+
+        /// <summary>
+        /// Resets per-run state. Called on RunStart so a Try Again from the
+        /// results screen starts with a fresh banish list, fresh owned-cards
+        /// list, and an empty pending-level queue. Without this, a previous
+        /// run's banishments could carry over (currently masked by the fact
+        /// that scene-bound managers are recreated on scene reload, but
+        /// resetting here removes that dependency).
+        /// </summary>
+        private void ResetRunScopedState()
+        {
+            _ownedCardIds.Clear();
+            _banishedCardIds.Clear();
+            _pendingLevels.Clear();
+            _screenActive = false;
+        }
+
+        /// <summary>
+        /// Defensive fallback in case a level-up somehow fires before RunStart
+        /// (direct-Play testing, time-travel via debug command, etc.). Returns
+        /// true if PlayerStats is now valid; false if we genuinely can't find it.
+        /// In the normal flow this is a no-op since CachePlayerRefs already ran.
+        /// </summary>
+        private bool EnsurePlayerStats()
+        {
+            if (playerStats != null) return true;
+            CachePlayerRefs();
+            return playerStats != null;
         }
 
         // ─── Level-up flow ────────────────────────────────────────────────
 
-        private void HandleLevelUp(int newLevel)
+        private void EnqueueLevelUp(int newLevel)
         {
             _pendingLevels.Enqueue(newLevel);
             if (verbose)
@@ -194,8 +253,10 @@ namespace CyberPickle.Gameplay.Progression
             if (RunStateManager.Instance != null)
                 RunStateManager.Instance.TransitionTo(RunStatePhase.LevelUpPaused);
 
-            // Draw cards.
-            float luck = playerStats != null ? playerStats.Get(PlayerStatType.Luck) : 0f;
+            // Draw cards. Pull Luck for rarity weighting; tolerate missing
+            // PlayerStats (would only happen on a direct-Play test that
+            // skipped the bootstrap) and just use luck=0.
+            float luck = EnsurePlayerStats() ? playerStats.Get(PlayerStatType.Luck) : 0f;
             var cards = pool.DrawCards(cardsPerOffer, luck, _banishedCardIds, _ownedCardIds);
 
             if (cards.Count == 0)

--- a/Assets/_CyberPickle/Code/Gameplay/Progression/LevelUpCoordinator.cs.meta
+++ b/Assets/_CyberPickle/Code/Gameplay/Progression/LevelUpCoordinator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cbecf91ed2740a64b8dda47b9a440bf9

--- a/Assets/_CyberPickle/Code/Gameplay/Progression/UpgradeCardSO.cs
+++ b/Assets/_CyberPickle/Code/Gameplay/Progression/UpgradeCardSO.cs
@@ -1,0 +1,130 @@
+// File: Assets/_CyberPickle/Code/Gameplay/Progression/UpgradeCardSO.cs
+// Namespace: CyberPickle.Gameplay.Progression
+//
+// One Upgrade Card asset — the unit of choice on the level-up screen.
+// Authored as a ScriptableObject so designers can iterate without code
+// changes; runtime instances are picked from an UpgradePoolSO and applied
+// via PlayerStats.AddModifier when the player picks the card.
+//
+// Card is intentionally minimal at this stage. As the system matures we'll
+// add: 3D preview prefab reference (per GDD §3.11.4), Wwise hover-stinger
+// event id (per §3.11.4), element color tint, prerequisites (some cards
+// only appear once a related card is owned), per-card synergy hints.
+// Those slots are stubbed out below as TODO fields so adding them later
+// is a matter of filling values, not refactoring.
+//
+// Why one SO per card vs a Dictionary on a single SO: addressability,
+// inspector-friendliness, and per-card meta tags can be added without
+// migrating data. Costs ~1 .asset file per card; with 50+ cards that's
+// trivial.
+
+using System.Collections.Generic;
+using UnityEngine;
+using CyberPickle.Gameplay.Stats;
+
+namespace CyberPickle.Gameplay.Progression
+{
+    /// <summary>
+    /// Rarity tier for level-up cards. Drives draw weighting (Luck stat
+    /// modulates the weights — more Luck = higher chance of better rarities).
+    /// </summary>
+    public enum CardRarity : byte
+    {
+        Common    = 0,
+        Uncommon  = 1,
+        Rare      = 2,
+        Epic      = 3,
+        Legendary = 4,
+    }
+
+    [CreateAssetMenu(menuName = "CyberPickle/Progression/Upgrade Card", fileName = "Card_")]
+    public class UpgradeCardSO : ScriptableObject
+    {
+        [Header("Identity")]
+        [Tooltip("Stable id for save data, banishment, and run-history tracking. MUST be unique across all cards. Convention: lowercase_snake_case ('power_minor', 'magnet_radius_1').")]
+        public string cardId;
+
+        [Tooltip("User-facing name shown on the card UI. Short — fits a card header.")]
+        public string displayName;
+
+        [Tooltip("User-facing one-liner. Optional with the new visual-first card UI (per GDD §3.11.4 the icon + 3D preview do most of the talking) but useful as a fallback / accessibility text.")]
+        [TextArea(2, 4)]
+        public string description;
+
+        [Tooltip("Sprite icon shown on the card. Will be supplemented by the 3D preview rig (TODO field below).")]
+        public Sprite icon;
+
+        [Header("Theming")]
+        [Tooltip("Primary card color. Per GDD §3.11.4, color = element. Pure-stat cards use a neutral chrome color (RGB 0.7,0.7,0.75 or similar).")]
+        public Color tintColor = new Color(0.7f, 0.7f, 0.75f, 1f);
+
+        [Header("Rarity")]
+        [Tooltip("Rarity tier — drives the draw weighting in UpgradePoolSO.")]
+        public CardRarity rarity = CardRarity.Common;
+
+        [Header("Effect")]
+        [Tooltip("Stat modifiers applied when this card is picked. ALL modifiers in the array are applied together via PlayerStats.AddModifier. Their sourceIds are prefixed at apply-time with this card's RuntimeSourceId so they can be batch-removed if the card is ever 'forgotten' (future feature).")]
+        public StatModifier[] modifiers;
+
+        // ─── TODO fields (stubbed for forward compatibility) ──────────────
+
+        [Header("TODO — wire as systems mature")]
+        [Tooltip("3D model preview prefab shown in the card slot's mini-camera viewport (per GDD §3.11.4). Leave empty for now — placeholder primitives during M7.3 day 3-4 UI work.")]
+        public GameObject previewPrefab;
+
+        [Tooltip("Wwise event id for the hover-stinger preview (per GDD §3.11.4). Leave empty until M9 Wwise integration; Stage 0 / 1 use placeholder UI sounds via the MusicEventBus.")]
+        public string hoverStingerEventId;
+
+        [Tooltip("Optional list of element tags this card belongs to (for color override + synergy callouts). Leave empty for pure-stat cards.")]
+        public List<string> elementTags;
+
+        [Tooltip("Optional list of prerequisite cardIds. If set, this card can only be drawn once ALL listed cards are already owned. Empty = no prerequisites.")]
+        public List<string> prerequisiteCardIds;
+
+        // ─── Runtime helpers ──────────────────────────────────────────────
+
+        /// <summary>
+        /// SourceId prefix used when applying this card's modifiers to
+        /// PlayerStats. The prefix scheme aligns with StatModifier's documented
+        /// convention ("run_*" for in-run upgrades). Each modifier's individual
+        /// sourceId is the card's id; if the same card is picked twice (multi-stack
+        /// upgrades, e.g., +10% Power × N), the modifiers stack additively because
+        /// AddPercent is associative — no need to disambiguate stacks.
+        /// </summary>
+        public string RuntimeSourceId => $"run_{cardId}";
+
+        /// <summary>
+        /// Applies this card's modifiers to the supplied PlayerStats instance.
+        /// Returns the number of modifiers actually applied (in case any are
+        /// invalid / skippable).
+        /// </summary>
+        public int ApplyTo(PlayerStats stats)
+        {
+            if (stats == null || modifiers == null) return 0;
+            string source = RuntimeSourceId;
+            int count = 0;
+            for (int i = 0; i < modifiers.Length; i++)
+            {
+                // Override the per-modifier sourceId at apply-time so authors
+                // don't have to remember to set it correctly per card.
+                var m = modifiers[i];
+                m.sourceId = source;
+                stats.AddModifier(m);
+                count++;
+            }
+            return count;
+        }
+
+        // ─── Editor validation ────────────────────────────────────────────
+
+#if UNITY_EDITOR
+        private void OnValidate()
+        {
+            if (string.IsNullOrWhiteSpace(cardId))
+            {
+                cardId = name?.ToLower().Replace(" ", "_") ?? "unnamed_card";
+            }
+        }
+#endif
+    }
+}

--- a/Assets/_CyberPickle/Code/Gameplay/Progression/UpgradeCardSO.cs.meta
+++ b/Assets/_CyberPickle/Code/Gameplay/Progression/UpgradeCardSO.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: eed9819a0a1f2914ba11fbb5034bb9dc

--- a/Assets/_CyberPickle/Code/Gameplay/Progression/UpgradePoolSO.cs
+++ b/Assets/_CyberPickle/Code/Gameplay/Progression/UpgradePoolSO.cs
@@ -1,0 +1,164 @@
+// File: Assets/_CyberPickle/Code/Gameplay/Progression/UpgradePoolSO.cs
+// Namespace: CyberPickle.Gameplay.Progression
+//
+// Container for the set of UpgradeCardSO assets the player can be offered
+// during a run. The level-up coordinator queries this pool for the 3 cards
+// to display each level-up.
+//
+// Drawing rules:
+//   - Filtered by banished cards (per-run banish list, applied via Banish
+//     button on level-up screen — wired in M9 economy work)
+//   - Filtered by prerequisite cards (a card with prereqs only appears
+//     once all listed cards are owned)
+//   - Weighted by rarity, with Luck stat modulating the weights toward
+//     higher rarities
+//
+// Why a separate pool SO instead of "all UpgradeCardSO assets in the
+// project": pools are scoped per-character / per-run / per-level. Pik's
+// pool may be different from a future archetype's. Boss treasure pools
+// only contain Legendary cards. Centralized pools also let the team
+// balance weight tuning in one place per pool, not per-card.
+
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace CyberPickle.Gameplay.Progression
+{
+    [CreateAssetMenu(menuName = "CyberPickle/Progression/Upgrade Pool", fileName = "Pool_")]
+    public class UpgradePoolSO : ScriptableObject
+    {
+        [Header("Identity")]
+        [Tooltip("Pool id for diagnostics. Convention: 'default' for the global default pool; '<character_id>' for per-character pools.")]
+        public string poolId = "default";
+
+        [Header("Cards")]
+        [Tooltip("Every card available in this pool. Order doesn't matter — drawing is weighted by rarity.")]
+        public UpgradeCardSO[] cards;
+
+        [Header("Rarity Weights (default; Luck modulates these at draw time)")]
+        [Tooltip("Relative draw weight for Common cards. Higher = more frequent. Defaults sum to 100 for sanity but absolute values don't matter — only ratios.")]
+        [Min(0f)] public float weightCommon    = 60f;
+        [Min(0f)] public float weightUncommon  = 25f;
+        [Min(0f)] public float weightRare      = 10f;
+        [Min(0f)] public float weightEpic      = 4f;
+        [Min(0f)] public float weightLegendary = 1f;
+
+        [Header("Luck Modulation")]
+        [Tooltip("How aggressively Luck shifts weight from Common→Legendary. At Luck=0 weights are unchanged. At Luck=100 + this multiplier 0.5, weights for Rare/Epic/Legendary are 50% higher and Common 50% lower (tunable). Ship safely below 1 to avoid game-breaking-rarity-flooding.")]
+        [Range(0f, 1f)] public float luckShiftPerHundred = 0.5f;
+
+        // ─── Drawing API ──────────────────────────────────────────────────
+
+        /// <summary>
+        /// Draws up to <paramref name="count"/> distinct cards from the pool,
+        /// filtered by the supplied predicates and weighted by rarity (modulated
+        /// by Luck). Returns fewer than <paramref name="count"/> cards if the
+        /// pool can't satisfy the request (e.g., everything banished, low pool size).
+        /// </summary>
+        /// <param name="count">How many cards to draw (typically 3).</param>
+        /// <param name="luck">Player Luck stat. 0+ — modulates rarity weights.</param>
+        /// <param name="banishedCardIds">CardIds banished this run; will be skipped.</param>
+        /// <param name="ownedCardIds">CardIds the player already has; used for prerequisite checks.</param>
+        public List<UpgradeCardSO> DrawCards(
+            int count,
+            float luck,
+            HashSet<string> banishedCardIds,
+            HashSet<string> ownedCardIds)
+        {
+            var result = new List<UpgradeCardSO>(count);
+            if (cards == null || cards.Length == 0) return result;
+
+            // Build the eligible list once (filters applied).
+            var eligible = new List<UpgradeCardSO>(cards.Length);
+            for (int i = 0; i < cards.Length; i++)
+            {
+                var c = cards[i];
+                if (c == null) continue;
+                if (banishedCardIds != null && banishedCardIds.Contains(c.cardId)) continue;
+                if (!PrerequisitesMet(c, ownedCardIds)) continue;
+                eligible.Add(c);
+            }
+
+            if (eligible.Count == 0) return result;
+
+            // Compute per-card weights (rarity weight × Luck modulation).
+            var weights = new float[eligible.Count];
+            float totalWeight = 0f;
+            for (int i = 0; i < eligible.Count; i++)
+            {
+                weights[i] = ComputeWeight(eligible[i].rarity, luck);
+                totalWeight += weights[i];
+            }
+
+            // Sample without replacement: pick, remove from local pool, repeat.
+            for (int draw = 0; draw < count && eligible.Count > 0; draw++)
+            {
+                if (totalWeight <= 0f) break;
+
+                float roll = UnityEngine.Random.value * totalWeight;
+                float running = 0f;
+                int picked = 0;
+                for (int i = 0; i < eligible.Count; i++)
+                {
+                    running += weights[i];
+                    if (roll <= running)
+                    {
+                        picked = i;
+                        break;
+                    }
+                }
+
+                result.Add(eligible[picked]);
+                totalWeight -= weights[picked];
+                eligible.RemoveAt(picked);
+                // O(n) array shift; weights array kept in sync via swap-and-pop.
+                weights[picked] = weights[eligible.Count];
+            }
+
+            return result;
+        }
+
+        // ─── Internals ────────────────────────────────────────────────────
+
+        private float ComputeWeight(CardRarity rarity, float luck)
+        {
+            float baseWeight = rarity switch
+            {
+                CardRarity.Common    => weightCommon,
+                CardRarity.Uncommon  => weightUncommon,
+                CardRarity.Rare      => weightRare,
+                CardRarity.Epic      => weightEpic,
+                CardRarity.Legendary => weightLegendary,
+                _                    => 0f,
+            };
+
+            // Luck modulation: shift weight from Common toward higher rarities.
+            // shiftAmount in [0..1]; lower rarities scale down, higher scale up.
+            float shiftAmount = Mathf.Clamp01((luck * 0.01f) * luckShiftPerHundred);
+            float multiplier = rarity switch
+            {
+                CardRarity.Common    => 1f - shiftAmount,
+                CardRarity.Uncommon  => 1f - shiftAmount * 0.4f,  // slightly down
+                CardRarity.Rare      => 1f + shiftAmount * 0.5f,  // up
+                CardRarity.Epic      => 1f + shiftAmount * 1.0f,
+                CardRarity.Legendary => 1f + shiftAmount * 1.5f,
+                _                    => 1f,
+            };
+
+            return Mathf.Max(0f, baseWeight * multiplier);
+        }
+
+        private static bool PrerequisitesMet(UpgradeCardSO card, HashSet<string> ownedCardIds)
+        {
+            if (card.prerequisiteCardIds == null || card.prerequisiteCardIds.Count == 0)
+                return true;
+            if (ownedCardIds == null) return false;
+            for (int i = 0; i < card.prerequisiteCardIds.Count; i++)
+            {
+                if (!ownedCardIds.Contains(card.prerequisiteCardIds[i]))
+                    return false;
+            }
+            return true;
+        }
+    }
+}

--- a/Assets/_CyberPickle/Code/Gameplay/Progression/UpgradePoolSO.cs.meta
+++ b/Assets/_CyberPickle/Code/Gameplay/Progression/UpgradePoolSO.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d4791f168b9c65f49b8257bc4a6b8ee0

--- a/Assets/_CyberPickle/Code/Gameplay/RunState/RunStateManager.cs
+++ b/Assets/_CyberPickle/Code/Gameplay/RunState/RunStateManager.cs
@@ -24,6 +24,7 @@
 using System;
 using UnityEngine;
 using CyberPickle.Core.Management;
+using CyberPickle.Gameplay.Audio;
 
 namespace CyberPickle.Gameplay.RunState
 {
@@ -89,6 +90,25 @@ namespace CyberPickle.Gameplay.RunState
             }
 
             OnPhaseChanged?.Invoke(phase);
+
+            // Broadcast onto the audio bus too. The Stage 0 listener (the
+            // MusicConductor stub) uses PhaseChanged + RunStart to align
+            // its beat clock; future Wwise integration will use these to
+            // swap music states (combat / paused / boss / death).
+            MusicEventBus.Fire(MusicEvent.PhaseChanged, phase);
+
+            // The first transition into Running is the canonical "run started"
+            // moment for music — fire the dedicated event so consumers don't
+            // have to filter PhaseChanged for the Running case.
+            if (phase == RunStatePhase.Running &&
+                (previous == RunStatePhase.Loading || previous == RunStatePhase.GameOver))
+            {
+                MusicEventBus.Fire(MusicEvent.RunStart);
+            }
+            else if (phase == RunStatePhase.GameOver)
+            {
+                MusicEventBus.Fire(MusicEvent.RunEnd);
+            }
         }
 
         // ─── Lifecycle ────────────────────────────────────────────────────

--- a/Assets/_CyberPickle/Code/Gameplay/Weapons/WeaponFiring.cs
+++ b/Assets/_CyberPickle/Code/Gameplay/Weapons/WeaponFiring.cs
@@ -23,6 +23,7 @@ using Unity.Mathematics;
 using Unity.Transforms;
 using UnityEngine;
 using CyberPickle.DOTS.Components;
+using CyberPickle.Gameplay.Audio;
 
 namespace CyberPickle.Gameplay.Weapons
 {
@@ -122,6 +123,15 @@ namespace CyberPickle.Gameplay.Weapons
             entityManager.SetComponentData(projectile, new ProjectileVelocity { Value = velocity });
             entityManager.SetComponentData(projectile, new ProjectileDamage   { Value = projectileDamage });
             entityManager.SetComponentData(projectile, new Lifetime           { Remaining = projectileLifetime });
+
+            // Broadcast to the audio bus. Stage 0: a Debug.Log entry per shot
+            // (only when VerboseLogging is on — off by default to avoid log
+            // flood). Stage 2 (M9 Wwise): this becomes the per-shot Ak event
+            // post that schedules the weapon's musical note on the next grid
+            // boundary. The payload will eventually carry weapon-id + element
+            // so the conductor can pick the right pitch/sample; for the stub
+            // we just signal that A shot happened.
+            MusicEventBus.Fire(MusicEvent.WeaponFire, gameObject.name);
         }
     }
 }

--- a/Assets/_CyberPickle/Code/UI/Screens/LevelUp/CardSlot.cs
+++ b/Assets/_CyberPickle/Code/UI/Screens/LevelUp/CardSlot.cs
@@ -1,0 +1,161 @@
+// File: Assets/_CyberPickle/Code/UI/Screens/LevelUp/CardSlot.cs
+// Namespace: CyberPickle.UI.Screens.LevelUp
+//
+// One card slot in the level-up choice screen. Binds an UpgradeCardSO to
+// the slot's visual elements (background tint, icon, name, description,
+// rarity badge), and surfaces hover + click as C# callbacks the parent
+// controller wires up.
+//
+// Why a separate component (not just inline in LevelUpScreenController):
+// - Clean separation: controller owns flow, slot owns view
+// - Easy to instantiate from a prefab if we move from "3 pre-authored
+//   slots" to "instantiate slot prefabs at runtime" later
+// - Hover/click handlers via UI EventSystem stay scoped to the slot,
+//   not coupled to the parent
+//
+// Hover behavior fires MusicEvent.CardHover with the cardId payload.
+// Stage 0 audio bus stub just logs it; Stage 2 (M9 Wwise) maps to a
+// hover-stinger preview per the GDD §3.11.4 differentiator.
+
+using System;
+using TMPro;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+using CyberPickle.Gameplay.Audio;
+using CyberPickle.Gameplay.Progression;
+
+namespace CyberPickle.UI.Screens.LevelUp
+{
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(CanvasGroup))]
+    public class CardSlot : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
+    {
+        [Header("Visual References")]
+        [Tooltip("Background image — its color is tinted to the card's element color (or neutral chrome for stat cards). Required.")]
+        [SerializeField] private Image backgroundImage;
+
+        [Tooltip("Icon image. Optional — if the card has no icon, the slot just shows the background tint.")]
+        [SerializeField] private Image iconImage;
+
+        [Tooltip("TMP for the card's display name. Required.")]
+        [SerializeField] private TextMeshProUGUI nameText;
+
+        [Tooltip("TMP for the card's description. Optional — visual-first cards may leave this blank.")]
+        [SerializeField] private TextMeshProUGUI descriptionText;
+
+        [Tooltip("TMP for the rarity badge ('COMMON', 'RARE', etc.). Optional.")]
+        [SerializeField] private TextMeshProUGUI rarityText;
+
+        [Header("Interaction")]
+        [Tooltip("The pick button — usually the entire card area. Required.")]
+        [SerializeField] private Button pickButton;
+
+        [Tooltip("Optional banish button (small X). Click removes the card from this run's pool. Hidden if not assigned.")]
+        [SerializeField] private Button banishButton;
+
+        // ─── Public events ────────────────────────────────────────────────
+
+        /// <summary>Fired when the player clicks the slot to pick this card.</summary>
+        public event Action<CardSlot> OnPicked;
+
+        /// <summary>Fired when the player clicks the banish button on this slot.</summary>
+        public event Action<CardSlot> OnBanished;
+
+        // ─── Public state ─────────────────────────────────────────────────
+
+        public UpgradeCardSO Card { get; private set; }
+
+        // ─── Lifecycle ────────────────────────────────────────────────────
+
+        private void Awake()
+        {
+            if (pickButton != null)   pickButton.onClick.AddListener(HandlePickClicked);
+            if (banishButton != null) banishButton.onClick.AddListener(HandleBanishClicked);
+        }
+
+        private void OnDestroy()
+        {
+            if (pickButton != null)   pickButton.onClick.RemoveListener(HandlePickClicked);
+            if (banishButton != null) banishButton.onClick.RemoveListener(HandleBanishClicked);
+        }
+
+        // ─── Public API ───────────────────────────────────────────────────
+
+        /// <summary>
+        /// Bind a card to this slot. Updates all visuals. Pass null to clear
+        /// (used when the slot is recycled across level-ups).
+        /// </summary>
+        public void Bind(UpgradeCardSO card)
+        {
+            Card = card;
+
+            if (card == null)
+            {
+                gameObject.SetActive(false);
+                return;
+            }
+
+            gameObject.SetActive(true);
+
+            if (backgroundImage != null)
+                backgroundImage.color = card.tintColor;
+
+            if (iconImage != null)
+            {
+                iconImage.sprite = card.icon;
+                iconImage.enabled = card.icon != null;
+            }
+
+            if (nameText != null)
+                nameText.text = card.displayName;
+
+            if (descriptionText != null)
+                descriptionText.text = card.description ?? string.Empty;
+
+            if (rarityText != null)
+                rarityText.text = card.rarity.ToString().ToUpperInvariant();
+
+            // Hide banish button if not configured. Future: hide based on
+            // whether banishment is allowed for this run (token currency check).
+            if (banishButton != null)
+                banishButton.gameObject.SetActive(true);
+        }
+
+        /// <summary>Disable interaction (e.g., during the pick-completion animation).</summary>
+        public void SetInteractable(bool interactable)
+        {
+            if (pickButton != null)   pickButton.interactable   = interactable;
+            if (banishButton != null) banishButton.interactable = interactable;
+        }
+
+        // ─── Event handlers ───────────────────────────────────────────────
+
+        public void OnPointerEnter(PointerEventData eventData)
+        {
+            if (Card == null) return;
+            // Bus event drives the hover-stinger preview (Stage 0 = log,
+            // Stage 2 = Wwise event post). See GDD §3.11.4.
+            MusicEventBus.Fire(MusicEvent.CardHover, Card.cardId);
+        }
+
+        public void OnPointerExit(PointerEventData eventData)
+        {
+            // No bus event on exit — the hover stinger fades naturally.
+            // If audio team wants explicit exit handling later, add a
+            // CardHoverExit event to the enum.
+        }
+
+        private void HandlePickClicked()
+        {
+            if (Card == null) return;
+            OnPicked?.Invoke(this);
+        }
+
+        private void HandleBanishClicked()
+        {
+            if (Card == null) return;
+            OnBanished?.Invoke(this);
+        }
+    }
+}

--- a/Assets/_CyberPickle/Code/UI/Screens/LevelUp/LevelUpScreenController.cs
+++ b/Assets/_CyberPickle/Code/UI/Screens/LevelUp/LevelUpScreenController.cs
@@ -1,0 +1,217 @@
+// File: Assets/_CyberPickle/Code/UI/Screens/LevelUp/LevelUpScreenController.cs
+// Namespace: CyberPickle.UI.Screens.LevelUp
+//
+// The level-up choice screen UI. Subscribes to LevelUpCoordinator's
+// OnCardsDrawn event, populates the slots, fades in. Click on a slot
+// reports back to the coordinator and fades out.
+//
+// Critical detail: this UI runs while RunStateManager.CurrentPhase ==
+// LevelUpPaused, which sets Time.timeScale = 0. ALL animations and
+// timers MUST use unscaled time, or the UI will freeze the moment it
+// appears. Same defensive pattern we used for EquipmentHubManager fades
+// and the ResultsScreenController.
+//
+// What this is (Day 3, minimum viable):
+//   - 3 pre-authored CardSlot GameObjects in a CanvasGroup panel
+//   - Fade in / fade out via unscaled time
+//   - Click → coordinator
+//   - Banish click → coordinator
+//
+// What this is NOT (yet):
+//   - 3D model preview rigs per slot — Day 4
+//   - Hold-to-confirm picking — Day 5
+//   - Beat-aligned slow-mo (Time.timeScale = 0.05 instead of 0) — Day 5
+//   - Hover-stinger Wwise preview — handled at MusicEventBus listener
+//     level when Wwise integrates (M9, Stage 2 of audio rollout)
+//
+// Hierarchy convention (drop these in Game.unity under your Canvas):
+//
+//   [LevelUpScreenPanel]            ← CanvasGroup, alpha=0, !raycasts initially
+//     ├─ Background (full-screen dim)
+//     ├─ Title (TMP "LEVEL UP")
+//     ├─ Slot1 (CardSlot component)
+//     │   ├─ Background (Image)
+//     │   ├─ Icon (Image)
+//     │   ├─ Name (TMP)
+//     │   ├─ Description (TMP)
+//     │   ├─ Rarity (TMP)
+//     │   ├─ PickButton (Button on the whole card area)
+//     │   └─ BanishButton (Button, small X icon)
+//     ├─ Slot2 (CardSlot component, same layout)
+//     └─ Slot3 (CardSlot component, same layout)
+//
+// Drop LevelUpScreenController on [LevelUpScreenPanel]. Drag the 3
+// CardSlot components into the slots[] array. Wire panelGroup to the
+// CanvasGroup on the same GameObject.
+
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using CyberPickle.Gameplay.Progression;
+
+namespace CyberPickle.UI.Screens.LevelUp
+{
+    [DisallowMultipleComponent]
+    public class LevelUpScreenController : MonoBehaviour
+    {
+        [Header("Panel")]
+        [Tooltip("CanvasGroup driving the panel's visibility. Should start with alpha=0, interactable=false, blocksRaycasts=false.")]
+        [SerializeField] private CanvasGroup panelGroup;
+
+        [Tooltip("Seconds to fade the panel in / out. Uses unscaled time so it animates while the game is paused (Time.timeScale=0 during LevelUpPaused).")]
+        [Min(0f)] [SerializeField] private float fadeDuration = 0.4f;
+
+        [Header("Slots")]
+        [Tooltip("The card slots — typically 3, matching LevelUpCoordinator.cardsPerOffer. Each slot is a CardSlot MonoBehaviour authored in the scene.")]
+        [SerializeField] private CardSlot[] slots = new CardSlot[3];
+
+        [Header("Coordinator")]
+        [Tooltip("The level-up coordinator this screen subscribes to. Auto-discovered if left empty at OnEnable.")]
+        [SerializeField] private LevelUpCoordinator coordinator;
+
+        [Header("Diagnostics")]
+        [SerializeField] private bool verbose = true;
+
+        // ─── Lifecycle ────────────────────────────────────────────────────
+
+        private void Awake()
+        {
+            // Hidden until OnCardsDrawn fires.
+            SetPanelVisibility(0f, interactable: false);
+        }
+
+        private void OnEnable()
+        {
+            if (coordinator == null)
+                coordinator = FindFirstObjectByType<LevelUpCoordinator>();
+
+            if (coordinator != null)
+            {
+                coordinator.OnCardsDrawn += HandleCardsDrawn;
+            }
+            else
+            {
+                Debug.LogWarning("[LevelUpScreenController] No LevelUpCoordinator found. Screen will never display cards.");
+            }
+
+            // Wire each slot's pick + banish events to our local handlers.
+            for (int i = 0; i < slots.Length; i++)
+            {
+                if (slots[i] == null) continue;
+                slots[i].OnPicked   += HandleSlotPicked;
+                slots[i].OnBanished += HandleSlotBanished;
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (coordinator != null)
+                coordinator.OnCardsDrawn -= HandleCardsDrawn;
+
+            for (int i = 0; i < slots.Length; i++)
+            {
+                if (slots[i] == null) continue;
+                slots[i].OnPicked   -= HandleSlotPicked;
+                slots[i].OnBanished -= HandleSlotBanished;
+            }
+        }
+
+        // ─── Coordinator → UI ─────────────────────────────────────────────
+
+        private void HandleCardsDrawn(IReadOnlyList<UpgradeCardSO> cards)
+        {
+            if (verbose) Debug.Log($"[LevelUpScreen] Showing {cards.Count} cards.");
+
+            // Bind each slot. If the coordinator drew fewer cards than we
+            // have slots (small pool, lots banished), unused slots hide
+            // themselves via Bind(null).
+            for (int i = 0; i < slots.Length; i++)
+            {
+                if (slots[i] == null) continue;
+                UpgradeCardSO card = i < cards.Count ? cards[i] : null;
+                slots[i].Bind(card);
+                slots[i].SetInteractable(true);
+            }
+
+            StopAllCoroutines();
+            StartCoroutine(FadeIn());
+        }
+
+        // ─── Slot interactions → Coordinator ──────────────────────────────
+
+        private void HandleSlotPicked(CardSlot slot)
+        {
+            if (slot == null || slot.Card == null || coordinator == null) return;
+
+            if (verbose) Debug.Log($"[LevelUpScreen] Picked '{slot.Card.cardId}'.");
+
+            // Disable all slots immediately so a fast double-click can't
+            // pick two cards before the fade-out completes.
+            for (int i = 0; i < slots.Length; i++)
+                if (slots[i] != null) slots[i].SetInteractable(false);
+
+            // Apply via the coordinator (which transitions back to Running).
+            coordinator.NotifyCardPicked(slot.Card);
+
+            StopAllCoroutines();
+            StartCoroutine(FadeOut());
+        }
+
+        private void HandleSlotBanished(CardSlot slot)
+        {
+            if (slot == null || slot.Card == null || coordinator == null) return;
+
+            if (verbose) Debug.Log($"[LevelUpScreen] Banished '{slot.Card.cardId}'.");
+
+            // Banishment doesn't end the level-up — the player still has
+            // to pick from the remaining cards. Just clear the banished
+            // slot so the player visually understands it's gone.
+            coordinator.NotifyCardBanished(slot.Card);
+            slot.Bind(null);
+        }
+
+        // ─── Fades (unscaled time) ────────────────────────────────────────
+
+        private IEnumerator FadeIn()
+        {
+            if (panelGroup == null) yield break;
+
+            panelGroup.interactable   = true;
+            panelGroup.blocksRaycasts = true;
+
+            float elapsed = 0f;
+            while (elapsed < fadeDuration)
+            {
+                elapsed += Time.unscaledDeltaTime;
+                panelGroup.alpha = Mathf.Clamp01(elapsed / fadeDuration);
+                yield return null;
+            }
+            panelGroup.alpha = 1f;
+        }
+
+        private IEnumerator FadeOut()
+        {
+            if (panelGroup == null) yield break;
+
+            float elapsed = 0f;
+            while (elapsed < fadeDuration)
+            {
+                elapsed += Time.unscaledDeltaTime;
+                panelGroup.alpha = Mathf.Clamp01(1f - elapsed / fadeDuration);
+                yield return null;
+            }
+
+            panelGroup.alpha = 0f;
+            panelGroup.interactable   = false;
+            panelGroup.blocksRaycasts = false;
+        }
+
+        private void SetPanelVisibility(float alpha, bool interactable)
+        {
+            if (panelGroup == null) return;
+            panelGroup.alpha = alpha;
+            panelGroup.interactable   = interactable;
+            panelGroup.blocksRaycasts = interactable;
+        }
+    }
+}

--- a/Assets/_CyberPickle/Data/UI.meta
+++ b/Assets/_CyberPickle/Data/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fc37b0e285efab54e95b7f69cddc604a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_CyberPickle/Data/UI/Cards.meta
+++ b/Assets/_CyberPickle/Data/UI/Cards.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 544324ee422063c4287647f1be9f4f9f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_DexterityMinor.asset
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_DexterityMinor.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eed9819a0a1f2914ba11fbb5034bb9dc, type: 3}
   m_Name: Card_DexterityMinor
   m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.Gameplay.Progression.UpgradeCardSO
-  cardId: card_dexteritysmall
+  cardId: card_dexterityminor
   displayName: +10% Dexterity
   description: Dexterity increases fire rate for all weapons
   icon: {fileID: 0}

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_DexterityMinor.asset
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_DexterityMinor.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eed9819a0a1f2914ba11fbb5034bb9dc, type: 3}
+  m_Name: Card_DexterityMinor
+  m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.Gameplay.Progression.UpgradeCardSO
+  cardId: card_dexteritysmall
+  displayName: +10% Dexterity
+  description: Dexterity increases fire rate for all weapons
+  icon: {fileID: 0}
+  tintColor: {r: 0.7, g: 0.7, b: 0.75, a: 1}
+  rarity: 0
+  modifiers:
+  - type: 9
+    kind: 1
+    value: 10
+    sourceId: 
+  previewPrefab: {fileID: 0}
+  hoverStingerEventId: 
+  elementTags: []
+  prerequisiteCardIds: []

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_DexterityMinor.asset.meta
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_DexterityMinor.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cc9a9c6e11317ea4496b1274a742e408
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_MagnetSmall.asset
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_MagnetSmall.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eed9819a0a1f2914ba11fbb5034bb9dc, type: 3}
+  m_Name: Card_MagnetSmall
+  m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.Gameplay.Progression.UpgradeCardSO
+  cardId: 
+  displayName: 
+  description: 
+  icon: {fileID: 0}
+  tintColor: {r: 0.7, g: 0.7, b: 0.75, a: 1}
+  rarity: 0
+  modifiers: []
+  previewPrefab: {fileID: 0}
+  hoverStingerEventId: 
+  elementTags: []
+  prerequisiteCardIds: []

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_MagnetSmall.asset
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_MagnetSmall.asset
@@ -12,13 +12,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eed9819a0a1f2914ba11fbb5034bb9dc, type: 3}
   m_Name: Card_MagnetSmall
   m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.Gameplay.Progression.UpgradeCardSO
-  cardId: 
-  displayName: 
+  cardId: card_magnetsmall
+  displayName: +1 Magnetic Field
   description: 
   icon: {fileID: 0}
   tintColor: {r: 0.7, g: 0.7, b: 0.75, a: 1}
   rarity: 0
-  modifiers: []
+  modifiers:
+  - type: 7
+    kind: 0
+    value: 1
+    sourceId: 
   previewPrefab: {fileID: 0}
   hoverStingerEventId: 
   elementTags: []

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_MagnetSmall.asset.meta
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_MagnetSmall.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 11d4249a2b1179b4b8074be32670f0f0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_PowerMinor.asset
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_PowerMinor.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eed9819a0a1f2914ba11fbb5034bb9dc, type: 3}
+  m_Name: Card_PowerMinor
+  m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.Gameplay.Progression.UpgradeCardSO
+  cardId: 
+  displayName: 
+  description: 
+  icon: {fileID: 0}
+  tintColor: {r: 0.7, g: 0.7, b: 0.75, a: 1}
+  rarity: 0
+  modifiers: []
+  previewPrefab: {fileID: 0}
+  hoverStingerEventId: 
+  elementTags: []
+  prerequisiteCardIds: []

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_PowerMinor.asset
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_PowerMinor.asset
@@ -12,13 +12,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eed9819a0a1f2914ba11fbb5034bb9dc, type: 3}
   m_Name: Card_PowerMinor
   m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.Gameplay.Progression.UpgradeCardSO
-  cardId: 
-  displayName: 
+  cardId: card_powerminor
+  displayName: +10% Power
   description: 
   icon: {fileID: 0}
   tintColor: {r: 0.7, g: 0.7, b: 0.75, a: 1}
   rarity: 0
-  modifiers: []
+  modifiers:
+  - type: 3
+    kind: 1
+    value: 0.1
+    sourceId: 
   previewPrefab: {fileID: 0}
   hoverStingerEventId: 
   elementTags: []

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_PowerMinor.asset.meta
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_PowerMinor.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c7a117e3d3be5b3429e348293e0b2578
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_SpeedMinor.asset
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_SpeedMinor.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eed9819a0a1f2914ba11fbb5034bb9dc, type: 3}
+  m_Name: Card_SpeedMinor
+  m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.Gameplay.Progression.UpgradeCardSO
+  cardId: 
+  displayName: 
+  description: 
+  icon: {fileID: 0}
+  tintColor: {r: 0.7, g: 0.7, b: 0.75, a: 1}
+  rarity: 0
+  modifiers: []
+  previewPrefab: {fileID: 0}
+  hoverStingerEventId: 
+  elementTags: []
+  prerequisiteCardIds: []

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_SpeedMinor.asset
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_SpeedMinor.asset
@@ -12,13 +12,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eed9819a0a1f2914ba11fbb5034bb9dc, type: 3}
   m_Name: Card_SpeedMinor
   m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.Gameplay.Progression.UpgradeCardSO
-  cardId: 
-  displayName: 
+  cardId: card_speedminor
+  displayName: 5% Speed
   description: 
   icon: {fileID: 0}
   tintColor: {r: 0.7, g: 0.7, b: 0.75, a: 1}
   rarity: 0
-  modifiers: []
+  modifiers:
+  - type: 6
+    kind: 1
+    value: 5
+    sourceId: 
   previewPrefab: {fileID: 0}
   hoverStingerEventId: 
   elementTags: []

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_SpeedMinor.asset.meta
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_SpeedMinor.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 71467b13c49d9d0448f123f516e8a8f8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_CyberPickle/Data/UI/Cards/Pool_Default.asset
+++ b/Assets/_CyberPickle/Data/UI/Cards/Pool_Default.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d4791f168b9c65f49b8257bc4a6b8ee0, type: 3}
+  m_Name: Pool_Default
+  m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.Gameplay.Progression.UpgradePoolSO
+  poolId: default
+  cards: []
+  weightCommon: 60
+  weightUncommon: 25
+  weightRare: 10
+  weightEpic: 4
+  weightLegendary: 1
+  luckShiftPerHundred: 0.5

--- a/Assets/_CyberPickle/Data/UI/Cards/Pool_Default.asset
+++ b/Assets/_CyberPickle/Data/UI/Cards/Pool_Default.asset
@@ -13,7 +13,11 @@ MonoBehaviour:
   m_Name: Pool_Default
   m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.Gameplay.Progression.UpgradePoolSO
   poolId: default
-  cards: []
+  cards:
+  - {fileID: 11400000, guid: cc9a9c6e11317ea4496b1274a742e408, type: 2}
+  - {fileID: 11400000, guid: 11d4249a2b1179b4b8074be32670f0f0, type: 2}
+  - {fileID: 11400000, guid: c7a117e3d3be5b3429e348293e0b2578, type: 2}
+  - {fileID: 11400000, guid: 71467b13c49d9d0448f123f516e8a8f8, type: 2}
   weightCommon: 60
   weightUncommon: 25
   weightRare: 10

--- a/Assets/_CyberPickle/Data/UI/Cards/Pool_Default.asset.meta
+++ b/Assets/_CyberPickle/Data/UI/Cards/Pool_Default.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3f4b49ee1ac46c7468979805f7b80ac4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_CyberPickle/Scenes/Game/Game.unity
+++ b/Assets/_CyberPickle/Scenes/Game/Game.unity
@@ -119,6 +119,126 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &14474309
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 14474310}
+  - component: {fileID: 14474313}
+  - component: {fileID: 14474312}
+  - component: {fileID: 14474311}
+  m_Layer: 5
+  m_Name: BanishButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &14474310
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 14474309}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1940658946}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 84.236046, y: 184.45001}
+  m_SizeDelta: {x: 31.5279, y: 31.1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &14474311
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 14474309}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 14474312}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &14474312
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 14474309}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.990566, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: c6d6b8f2076e046418099d01efa1dbed, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &14474313
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 14474309}
+  m_CullTransparentMesh: 1
 --- !u!1 &140582583
 GameObject:
   m_ObjectHideFlags: 0
@@ -397,6 +517,431 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 169911565}
   m_CullTransparentMesh: 1
+--- !u!1 &173131957
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 173131958}
+  - component: {fileID: 173131961}
+  - component: {fileID: 173131960}
+  - component: {fileID: 173131959}
+  m_Layer: 5
+  m_Name: BanishButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &173131958
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 173131957}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1071791098}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 84.236046, y: 184.45001}
+  m_SizeDelta: {x: 31.5279, y: 31.1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &173131959
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 173131957}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 173131960}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &173131960
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 173131957}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.990566, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: c6d6b8f2076e046418099d01efa1dbed, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &173131961
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 173131957}
+  m_CullTransparentMesh: 1
+--- !u!1 &197486197
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 197486198}
+  - component: {fileID: 197486200}
+  - component: {fileID: 197486199}
+  m_Layer: 5
+  m_Name: NameText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &197486198
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 197486197}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1940658946}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 143.9}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &197486199
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 197486197}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: NAME
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281874488
+  m_fontColor: {r: 0.21960786, g: 0.21960786, b: 0.21960786, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &197486200
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 197486197}
+  m_CullTransparentMesh: 1
+--- !u!1 &207336859
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 207336860}
+  - component: {fileID: 207336863}
+  - component: {fileID: 207336862}
+  - component: {fileID: 207336861}
+  m_Layer: 5
+  m_Name: PickButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &207336860
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 207336859}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1071791098}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 300}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &207336861
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 207336859}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 207336862}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &207336862
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 207336859}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &207336863
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 207336859}
+  m_CullTransparentMesh: 1
+--- !u!1 &300398872
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 300398874}
+  - component: {fileID: 300398873}
+  m_Layer: 0
+  m_Name: '[LevelUpCoordinator]'
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &300398873
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 300398872}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cbecf91ed2740a64b8dda47b9a440bf9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.Gameplay.Progression.LevelUpCoordinator
+  pool: {fileID: 11400000, guid: 3f4b49ee1ac46c7468979805f7b80ac4, type: 2}
+  playerStats: {fileID: 0}
+  cardsPerOffer: 3
+  verbose: 1
+--- !u!4 &300398874
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 300398872}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.50099, y: -0, z: 24.94781}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &301831459
 GameObject:
   m_ObjectHideFlags: 0
@@ -675,6 +1220,143 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 392805291}
   m_CullTransparentMesh: 1
+--- !u!1 &409085380
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 409085381}
+  - component: {fileID: 409085383}
+  - component: {fileID: 409085382}
+  m_Layer: 5
+  m_Name: DescriptionText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &409085381
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 409085380}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1071791098}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -129}
+  m_SizeDelta: {x: 200, y: 142}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &409085382
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 409085380}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Description
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4282795590
+  m_fontColor: {r: 0.2735849, g: 0.2735849, b: 0.2735849, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 39.9
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &409085383
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 409085380}
+  m_CullTransparentMesh: 1
 --- !u!1 &432071303
 GameObject:
   m_ObjectHideFlags: 0
@@ -845,6 +1527,143 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &477250077
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 477250078}
+  - component: {fileID: 477250080}
+  - component: {fileID: 477250079}
+  m_Layer: 5
+  m_Name: NameText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &477250078
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 477250077}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1071791098}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 143.9}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &477250079
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 477250077}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: NAME
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281874488
+  m_fontColor: {r: 0.21960786, g: 0.21960786, b: 0.21960786, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &477250080
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 477250077}
+  m_CullTransparentMesh: 1
 --- !u!1 &495653423
 GameObject:
   m_ObjectHideFlags: 0
@@ -889,6 +1708,81 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dfb6bc953e172c94f9e518ed293dfd32, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.Gameplay.RunState.RunStatsTracker
+--- !u!1 &551597029
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 551597030}
+  - component: {fileID: 551597032}
+  - component: {fileID: 551597031}
+  m_Layer: 5
+  m_Name: Slot3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &551597030
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 551597029}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 722683950}
+  - {fileID: 1678524421}
+  - {fileID: 2067407913}
+  - {fileID: 1086944829}
+  - {fileID: 1450390653}
+  - {fileID: 1467550218}
+  - {fileID: 2023258640}
+  m_Father: {fileID: 1230510421}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 300, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &551597031
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 551597029}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c50188ae43d5434ba2df2793d4ff86f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.UI.Screens.LevelUp.CardSlot
+  backgroundImage: {fileID: 722683951}
+  iconImage: {fileID: 1678524422}
+  nameText: {fileID: 2067407914}
+  descriptionText: {fileID: 1086944830}
+  rarityText: {fileID: 1450390654}
+  pickButton: {fileID: 1467550219}
+  banishButton: {fileID: 2023258641}
+--- !u!225 &551597032
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 551597029}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
 --- !u!1 &571977370
 GameObject:
   m_ObjectHideFlags: 0
@@ -1052,6 +1946,81 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &722683949
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 722683950}
+  - component: {fileID: 722683952}
+  - component: {fileID: 722683951}
+  m_Layer: 5
+  m_Name: BackgroundImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &722683950
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 722683949}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 551597030}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 400}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &722683951
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 722683949}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &722683952
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 722683949}
+  m_CullTransparentMesh: 1
 --- !u!1 &876127134
 GameObject:
   m_ObjectHideFlags: 0
@@ -1116,6 +2085,143 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &884267093
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 884267094}
+  - component: {fileID: 884267096}
+  - component: {fileID: 884267095}
+  m_Layer: 5
+  m_Name: RarityText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &884267094
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 884267093}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1940658946}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -59.2}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &884267095
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 884267093}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Rarity
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &884267096
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 884267093}
+  m_CullTransparentMesh: 1
 --- !u!1 &893570407
 GameObject:
   m_ObjectHideFlags: 0
@@ -1161,6 +2267,81 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &908551420
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 908551421}
+  - component: {fileID: 908551423}
+  - component: {fileID: 908551422}
+  m_Layer: 5
+  m_Name: BackgroundImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &908551421
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 908551420}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1071791098}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 400}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &908551422
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 908551420}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &908551423
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 908551420}
+  m_CullTransparentMesh: 1
 --- !u!1 &949834637
 GameObject:
   m_ObjectHideFlags: 0
@@ -1558,6 +2739,143 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1012770636}
   m_CullTransparentMesh: 1
+--- !u!1 &1027135005
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1027135006}
+  - component: {fileID: 1027135008}
+  - component: {fileID: 1027135007}
+  m_Layer: 5
+  m_Name: RarityText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1027135006
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1027135005}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1071791098}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -59.2}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1027135007
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1027135005}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Rarity
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1027135008
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1027135005}
+  m_CullTransparentMesh: 1
 --- !u!1 &1044611198
 GameObject:
   m_ObjectHideFlags: 0
@@ -1695,6 +3013,218 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1044611198}
   m_CullTransparentMesh: 1
+--- !u!1 &1071791097
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1071791098}
+  - component: {fileID: 1071791100}
+  - component: {fileID: 1071791099}
+  m_Layer: 5
+  m_Name: Slot2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1071791098
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1071791097}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 908551421}
+  - {fileID: 1305791334}
+  - {fileID: 477250078}
+  - {fileID: 409085381}
+  - {fileID: 1027135006}
+  - {fileID: 207336860}
+  - {fileID: 173131958}
+  m_Father: {fileID: 1230510421}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1071791099
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1071791097}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c50188ae43d5434ba2df2793d4ff86f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.UI.Screens.LevelUp.CardSlot
+  backgroundImage: {fileID: 908551422}
+  iconImage: {fileID: 1305791335}
+  nameText: {fileID: 477250079}
+  descriptionText: {fileID: 409085382}
+  rarityText: {fileID: 1027135007}
+  pickButton: {fileID: 207336861}
+  banishButton: {fileID: 173131959}
+--- !u!225 &1071791100
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1071791097}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
+--- !u!1 &1086944828
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1086944829}
+  - component: {fileID: 1086944831}
+  - component: {fileID: 1086944830}
+  m_Layer: 5
+  m_Name: DescriptionText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1086944829
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1086944828}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 551597030}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -129}
+  m_SizeDelta: {x: 200, y: 142}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1086944830
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1086944828}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Description
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4282795590
+  m_fontColor: {r: 0.2735849, g: 0.2735849, b: 0.2735849, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 39.9
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1086944831
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1086944828}
+  m_CullTransparentMesh: 1
 --- !u!1 &1170066646
 GameObject:
   m_ObjectHideFlags: 0
@@ -1753,6 +3283,119 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1230510420
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1230510421}
+  - component: {fileID: 1230510424}
+  - component: {fileID: 1230510423}
+  - component: {fileID: 1230510422}
+  - component: {fileID: 1230510425}
+  m_Layer: 5
+  m_Name: LevelUpScreenPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1230510421
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1230510420}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2136795665}
+  - {fileID: 1940658946}
+  - {fileID: 1071791098}
+  - {fileID: 551597030}
+  m_Father: {fileID: 1803396267}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1230510422
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1230510420}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d1a7e917635c3bb46997c84c72ece76f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.UI.Screens.LevelUp.LevelUpScreenController
+  panelGroup: {fileID: 1230510425}
+  fadeDuration: 0.4
+  slots:
+  - {fileID: 1940658947}
+  - {fileID: 1071791099}
+  - {fileID: 551597031}
+  coordinator: {fileID: 0}
+  verbose: 1
+--- !u!114 &1230510423
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1230510420}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.36862746}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1230510424
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1230510420}
+  m_CullTransparentMesh: 1
+--- !u!225 &1230510425
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1230510420}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
 --- !u!1 &1243800316
 GameObject:
   m_ObjectHideFlags: 0
@@ -1939,6 +3582,338 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1259588361}
+  m_CullTransparentMesh: 1
+--- !u!1 &1305791333
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1305791334}
+  - component: {fileID: 1305791336}
+  - component: {fileID: 1305791335}
+  m_Layer: 5
+  m_Name: IconImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1305791334
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1305791333}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1071791098}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 25}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1305791335
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1305791333}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.5424528, g: 1, b: 0.6131311, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1305791336
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1305791333}
+  m_CullTransparentMesh: 1
+--- !u!1 &1450390652
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1450390653}
+  - component: {fileID: 1450390655}
+  - component: {fileID: 1450390654}
+  m_Layer: 5
+  m_Name: RarityText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1450390653
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1450390652}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 551597030}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -59.2}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1450390654
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1450390652}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Rarity
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1450390655
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1450390652}
+  m_CullTransparentMesh: 1
+--- !u!1 &1467550217
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1467550218}
+  - component: {fileID: 1467550221}
+  - component: {fileID: 1467550220}
+  - component: {fileID: 1467550219}
+  m_Layer: 5
+  m_Name: PickButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1467550218
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1467550217}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 551597030}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 300}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1467550219
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1467550217}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1467550220}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1467550220
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1467550217}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1467550221
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1467550217}
   m_CullTransparentMesh: 1
 --- !u!1 &1484738661
 GameObject:
@@ -2186,6 +4161,201 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1627487757
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1627487758}
+  - component: {fileID: 1627487761}
+  - component: {fileID: 1627487760}
+  - component: {fileID: 1627487759}
+  m_Layer: 5
+  m_Name: PickButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1627487758
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1627487757}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1940658946}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 300}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1627487759
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1627487757}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1627487760}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1627487760
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1627487757}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1627487761
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1627487757}
+  m_CullTransparentMesh: 1
+--- !u!1 &1633583126
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1633583127}
+  - component: {fileID: 1633583129}
+  - component: {fileID: 1633583128}
+  m_Layer: 5
+  m_Name: IconImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1633583127
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1633583126}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1940658946}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 25}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1633583128
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1633583126}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.5424528, g: 1, b: 0.6131311, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1633583129
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1633583126}
+  m_CullTransparentMesh: 1
 --- !u!1 &1657020406
 GameObject:
   m_ObjectHideFlags: 0
@@ -2276,6 +4446,81 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1678524420
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1678524421}
+  - component: {fileID: 1678524423}
+  - component: {fileID: 1678524422}
+  m_Layer: 5
+  m_Name: IconImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1678524421
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1678524420}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 551597030}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 25}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1678524422
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1678524420}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.5424528, g: 1, b: 0.6131311, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1678524423
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1678524420}
+  m_CullTransparentMesh: 1
 --- !u!1 &1803396263
 GameObject:
   m_ObjectHideFlags: 0
@@ -2372,6 +4617,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 169911566}
+  - {fileID: 1230510421}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -2379,6 +4625,293 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &1839047031
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1839047032}
+  - component: {fileID: 1839047034}
+  - component: {fileID: 1839047033}
+  m_Layer: 5
+  m_Name: DescriptionText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1839047032
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1839047031}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1940658946}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -129}
+  m_SizeDelta: {x: 200, y: 142}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1839047033
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1839047031}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Description
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4282795590
+  m_fontColor: {r: 0.2735849, g: 0.2735849, b: 0.2735849, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 39.9
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1839047034
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1839047031}
+  m_CullTransparentMesh: 1
+--- !u!1 &1940658945
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1940658946}
+  - component: {fileID: 1940658948}
+  - component: {fileID: 1940658947}
+  m_Layer: 5
+  m_Name: Slot1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1940658946
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1940658945}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1941604889}
+  - {fileID: 1633583127}
+  - {fileID: 197486198}
+  - {fileID: 1839047032}
+  - {fileID: 884267094}
+  - {fileID: 1627487758}
+  - {fileID: 14474310}
+  m_Father: {fileID: 1230510421}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -300, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1940658947
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1940658945}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c50188ae43d5434ba2df2793d4ff86f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.UI.Screens.LevelUp.CardSlot
+  backgroundImage: {fileID: 1941604890}
+  iconImage: {fileID: 1633583128}
+  nameText: {fileID: 197486199}
+  descriptionText: {fileID: 1839047033}
+  rarityText: {fileID: 884267095}
+  pickButton: {fileID: 1627487759}
+  banishButton: {fileID: 14474311}
+--- !u!225 &1940658948
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1940658945}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
+--- !u!1 &1941604888
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1941604889}
+  - component: {fileID: 1941604891}
+  - component: {fileID: 1941604890}
+  m_Layer: 5
+  m_Name: BackgroundImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1941604889
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1941604888}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1940658946}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 400}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1941604890
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1941604888}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1941604891
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1941604888}
+  m_CullTransparentMesh: 1
 --- !u!1 &1983593473
 GameObject:
   m_ObjectHideFlags: 0
@@ -2790,6 +5323,126 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2023258639
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2023258640}
+  - component: {fileID: 2023258643}
+  - component: {fileID: 2023258642}
+  - component: {fileID: 2023258641}
+  m_Layer: 5
+  m_Name: BanishButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2023258640
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2023258639}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 551597030}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 84.236046, y: 184.45001}
+  m_SizeDelta: {x: 31.5279, y: 31.1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2023258641
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2023258639}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2023258642}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &2023258642
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2023258639}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.990566, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: c6d6b8f2076e046418099d01efa1dbed, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2023258643
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2023258639}
+  m_CullTransparentMesh: 1
 --- !u!1 &2059096375
 GameObject:
   m_ObjectHideFlags: 0
@@ -3057,6 +5710,143 @@ MonoBehaviour:
   m_CameraActivatedEvent:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &2067407912
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2067407913}
+  - component: {fileID: 2067407915}
+  - component: {fileID: 2067407914}
+  m_Layer: 5
+  m_Name: NameText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2067407913
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2067407912}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 551597030}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 143.9}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2067407914
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2067407912}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: NAME
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281874488
+  m_fontColor: {r: 0.21960786, g: 0.21960786, b: 0.21960786, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &2067407915
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2067407912}
+  m_CullTransparentMesh: 1
 --- !u!1 &2084178848
 GameObject:
   m_ObjectHideFlags: 0
@@ -3178,6 +5968,143 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2084178848}
   m_CullTransparentMesh: 1
+--- !u!1 &2136795664
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2136795665}
+  - component: {fileID: 2136795667}
+  - component: {fileID: 2136795666}
+  m_Layer: 5
+  m_Name: TitleText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2136795665
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2136795664}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1230510421}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 450}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2136795666
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2136795664}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Level Up
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &2136795667
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2136795664}
+  m_CullTransparentMesh: 1
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -3200,3 +6127,4 @@ SceneRoots:
   - {fileID: 1803396267}
   - {fileID: 1657020409}
   - {fileID: 625675775}
+  - {fileID: 300398874}

--- a/Assets/_CyberPickle/Scenes/Game/Game.unity
+++ b/Assets/_CyberPickle/Scenes/Game/Game.unity
@@ -1004,6 +1004,53 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &625675773
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 625675775}
+  - component: {fileID: 625675774}
+  m_Layer: 0
+  m_Name: '[MusicConductor]'
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &625675774
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 625675773}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1074df45eeb9b074c8cf48b96e9df101, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.Gameplay.Audio.MusicConductor
+  bpm: 128
+  subdivisionsPerBeat: 4
+  verbose: 1
+--- !u!4 &625675775
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 625675773}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.62965, y: 4.14028, z: 17.80096}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &876127134
 GameObject:
   m_ObjectHideFlags: 0
@@ -3151,3 +3198,4 @@ SceneRoots:
   - {fileID: 495653424}
   - {fileID: 1803396267}
   - {fileID: 1657020409}
+  - {fileID: 625675775}

--- a/Assets/_CyberPickle/Scenes/Game/Game.unity
+++ b/Assets/_CyberPickle/Scenes/Game/Game.unity
@@ -1036,6 +1036,7 @@ MonoBehaviour:
   bpm: 128
   subdivisionsPerBeat: 4
   verbose: 1
+  verboseEventBus: 1
 --- !u!4 &625675775
 Transform:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Summary

Closes the end-to-end run loop: kill enemies → level up → 3-card choice screen → pick → modifiers apply → run resumes. Plus the Stage 0 of the audio architecture — every gameplay system now broadcasts its events through MusicEventBus, ready for Wwise to consume in M9.

Visual polish (3D card-preview rigs, beat-aligned slow-mo, hold-to-confirm) is deferred to M7.3.x — the loop is functional now.

## Three layers shipped

### 1. Stage 0 audio scaffold
Per GDD §3.5.13 staged rollout. Code only — no Wwise yet.

- **MusicEvent** (enum) — canonical gameplay events the audio system reacts to.
- **MusicEventBus** (static) — process-global fan-out. Producers Fire(); consumers subscribe.
- **MusicConductor** (Manager<T>, scene-bound) — owns master tempo (default 128 BPM), 32-subdivision-per-bar grid (per the music-decisions lock), exposes OnBeat/OnBar/OnSubdivision events. Stage 0 stub — Stage 2 (M9) replaces with Wwise music callbacks.
- **6 producer wirings**: RunStateManager (PhaseChanged, RunStart, RunEnd), PlayerHealth (PlayerHit, PlayerHealed), WeaponFiring (WeaponFire), EnemyDeathSystem (EnemyDeath), PlayerXPBridge (LevelUp), LevelUpCoordinator (CardPicked, CardBanished).
- **Verbose toggles** on MusicConductor for diagnostic logging without touching code.

### 2. Card system (data + orchestration + UI)
Per GDD §3.11 with the design refinements from V0.6.

- **UpgradeCardSO** — one asset per upgrade. Holds displayName, description, icon, tintColor, rarity, StatModifier[]. Forward-compat fields (3D preview prefab, hover-stinger event id, element tags, prerequisites) stubbed for Day-4-5 polish.
- **UpgradePoolSO** — container with rarity-weighted draw, Luck modulation, banishment + prerequisite filtering. Sample-without-replacement.
- **PlayerXPBridge** (modified) — fires MusicEvent.LevelUp on threshold cross alongside existing C# event.
- **LevelUpCoordinator** — listens to MusicEventBus.OnEvent for LevelUp (process-global = no scene-load timing race, see hotfix commit). Caches PlayerStats once on RunStart instead of per-level-up to avoid O(n) scene scans. Manages level-up queue (multiple thresholds in one frame are processed FIFO). Resets per-run state on RunStart.
- **CardSlot** (UI view) — binds an UpgradeCardSO to its visual elements. IPointerEnterHandler fires MusicEvent.CardHover.
- **LevelUpScreenController** — fades panel in/out via unscaled time (timeScale=0 during LevelUpPaused). Click → coordinator. Banish → coordinator.
- **4 placeholder card SOs + 1 default pool** authored: DexterityMinor, MagnetSmall, PowerMinor, SpeedMinor.

### 3. Build hotfixes (committed first)
- **ProjectileCollisionSystem.cs**: Burst-incompatible System.Environment.TickCount in OnCreate was crashing player builds inside __codegen__OnCreate. Replaced with Random.CreateFromIndex(state.GlobalSystemVersion).
- **TMP SDFFunctions.hlsl**: lowercase texture2D type name broke 11 DXR shader passes. Capital T fix.

## Architecture notes worth highlighting

**Bus subscription over component subscription.** LevelUpCoordinator initially tried to subscribe to PlayerXPBridge.OnLevelUp directly, but coordinator OnEnable runs before GameSceneBootstrap.Start spawns the player — so FindFirstObjectByType returned null. Refactored to use the static MusicEventBus, which is alive from assembly load. No timing concerns. This pattern is the right answer for any bus-broadcast event the coordinator needs to consume.

**Per-run reset on RunStart.** LevelUpCoordinator clears _ownedCardIds, _banishedCardIds, _pendingLevels on every Loading→Running transition. Currently masked by scene-bound recreation, but explicit reset removes the dependency. Try Again now genuinely starts fresh.

**Time.unscaledDeltaTime everywhere in level-up UI.** RunStateManager.LevelUpPaused sets Time.timeScale=0; any UI that uses scaled time would freeze the moment it appears. Same defensive pattern as ResultsScreenController and the Equipment Hub fade.

## Test plan
- [x] Boot → CharacterSelect → EquipmentHub → Game (clean run)
- [x] Pick character → run starts → kill enemies
- [x] Cross XP threshold → MusicEventBus broadcasts LevelUp → coordinator queues + draws 3 cards → screen fades in
- [x] Game pauses (Time.timeScale=0)
- [x] Hover card → MusicEventBus.CardHover fires
- [x] Click card → modifier applies (verified: stat readout reflects new value)
- [x] Screen fades out, run resumes
- [x] Multi-level-up: collect a big XP cluster that crosses 2 thresholds in one frame → 2 sequential card screens, no batching
- [x] Banish a card mid-screen → it disappears, others remain interactable
- [x] Try Again from results screen → fresh card pool, no carryover banishment
- [x] Build compiles + runs (post-hotfix Burst RNG and TMP shader fixes)

## What's next (M7.4)
HUD + damage feedback channels per GDD §3.12. XP bar, health bar, run timer, kill counter, per-weapon DPS, selective damage numbers (crits + kills), hitstop, enemy state flash, particle bursts per element, player-side feedback (vignette, heartbeat). The visceral "make combat feel good" pass that completes the vertical slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)