### PR TITLE
M8: cross loadout, element-coupled power-ups, slot-picker, Skip/Reroll, animation polish

### DIFF
--- a/Assets/_CyberPickle/Code/Gameplay/Audio/MusicEvent.cs
+++ b/Assets/_CyberPickle/Code/Gameplay/Audio/MusicEvent.cs
@@ -55,6 +55,9 @@ namespace CyberPickle.Gameplay.Audio
         // payload: card-id (string) — fires when the user picks a card
         CardPicked      = 32,
         CardBanished    = 33,
+        // payload: null — fired when the player skips an entire draft
+        // (no card picked). Adds +1 to LevelUpCoordinator.BankedRerolls.
+        CardSkipped     = 34,
         CardRerolled    = 34,
 
         // ─── Bosses ──────────────────────────────────────────────────────

--- a/Assets/_CyberPickle/Code/Gameplay/Audio/MusicEvent.cs
+++ b/Assets/_CyberPickle/Code/Gameplay/Audio/MusicEvent.cs
@@ -84,5 +84,24 @@ namespace CyberPickle.Gameplay.Audio
         WeaponEvolved       = 63,
         // payload: null
         LoadoutCleared      = 64,
+
+        // payload: int axisIndex — fires when an axis's weapon element changes,
+        // typically because a power-up was slotted/removed on the same axis
+        // (M8 element-coupling). The music conductor maps element → mode for
+        // that axis's pattern playback per procedural_music_reference.md §22.4.
+        WeaponElementChanged = 65,
+
+        // ─── Power-ups (M8 — element coupling on the axis) ────────────────
+        // Per-axis slot-state changes. Mirrors the Weapon* events above so
+        // the music conductor can react symmetrically (a power-up's rarity
+        // determines its visual + audio bonus depth, level scales magnitude).
+        // payload: int axisIndex
+        PowerUpAdded         = 70,
+        // payload: int axisIndex
+        PowerUpRemoved       = 71,
+        // payload: int axisIndex
+        PowerUpLevelChanged  = 72,
+        // payload: int axisIndex
+        PowerUpRarityChanged = 73,
     }
 }

--- a/Assets/_CyberPickle/Code/Gameplay/Progression/DraftedCard.cs
+++ b/Assets/_CyberPickle/Code/Gameplay/Progression/DraftedCard.cs
@@ -1,0 +1,56 @@
+// File: Assets/_CyberPickle/Code/Gameplay/Progression/DraftedCard.cs
+// Namespace: CyberPickle.Gameplay.Progression
+//
+// Runtime wrapper around an UpgradeCardSO with the values rolled at
+// draft time:
+//   - Rarity (rolled per the pool's Luck-modulated weights)
+//   - Element (rolled uniformly per the 7 elements; only meaningful for
+//     power-up cards)
+//
+// Why this exists: a single power-up template asset (e.g., "Fire-Rate
+// Boost") shows up as multiple element-flavored cards in the draft —
+// Fire / Lightning / Ice / etc. — without authoring a separate asset
+// per element. The pool drawing logic rolls the element at draft time
+// and stores it on this struct.
+//
+// For non-power-up cards (StatModifier buffs, Weapon level-ups, etc.),
+// the rolled element is ElementId.None and ignored when the card is
+// applied.
+
+using CyberPickle.Core;
+
+namespace CyberPickle.Gameplay.Progression
+{
+    /// <summary>
+    /// One drafted card — a template (UpgradeCardSO) plus the values
+    /// rolled at draft time.
+    /// </summary>
+    public struct DraftedCard
+    {
+        /// <summary>The template asset. Carries all immutable design data.</summary>
+        public UpgradeCardSO source;
+
+        /// <summary>Rarity rolled at draft time (per pool's Luck-modulated weights).</summary>
+        public Rarity rolledRarity;
+
+        /// <summary>
+        /// Element rolled at draft time. Only meaningful for
+        /// <see cref="CardType.NewPowerUp"/> cards — other types ignore
+        /// this field and use ElementId.None.
+        /// </summary>
+        public ElementId rolledElement;
+
+        public bool IsValid => source != null;
+        public string CardId => source != null ? source.cardId : string.Empty;
+        public CardType Kind => source != null ? source.cardType : CardType.StatModifier;
+
+        /// <summary>
+        /// True if the player has to pick a slot on the cross UI before
+        /// the card can be applied. Used by the level-up screen to enter
+        /// a "slot-picker" mode after a slottable card is clicked.
+        /// </summary>
+        public bool RequiresSlotSelection
+            => source != null && (source.cardType == CardType.NewWeapon ||
+                                  source.cardType == CardType.NewPowerUp);
+    }
+}

--- a/Assets/_CyberPickle/Code/Gameplay/Progression/DraftedCard.cs.meta
+++ b/Assets/_CyberPickle/Code/Gameplay/Progression/DraftedCard.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5ef55b7f3520f024a9076e2847a68fc9

--- a/Assets/_CyberPickle/Code/Gameplay/Progression/LevelUpCoordinator.cs
+++ b/Assets/_CyberPickle/Code/Gameplay/Progression/LevelUpCoordinator.cs
@@ -11,33 +11,36 @@
 //      coordinator silently never subscribed. The MusicEventBus is a static
 //      class — process-global, alive from assembly load — so bus
 //      subscriptions don't care about scene-load timing.)
-//   2. On level-up: transitions RunStateManager → LevelUpPaused (per
-//      GDD §3.11, this freezes Time.timeScale. Future M7.3-day-5 polish
-//      replaces full pause with timeScale=0.05 slow-mo).
-//   3. Draws N cards from the active UpgradePoolSO (filtered by banished
-//      + prerequisite, weighted by Luck).
+//   2. On level-up: transitions RunStateManager → LevelUpPaused.
+//   3. Draws N cards from the active UpgradePoolSO. N is Luck-driven
+//      via RarityRollService.CardsVisibleForLuck (3 base, +1 per 50 Luck,
+//      cap 6 — see CLAUDE.md design pillar). Cards are filtered against
+//      the current loadout state (no NewWeapon when slots full, no
+//      LevelUpWeapon for un-equipped weapons, etc.).
 //   4. Raises OnCardsDrawn for the UI (LevelUpScreenController).
-//   5. Awaits a card pick via NotifyCardPicked() (called by the UI).
-//   6. Applies the picked card's modifiers to PlayerStats, records the
-//      pick in OwnedCardIds for prerequisite tracking, fires
-//      MusicEvent.CardPicked.
+//   5. Awaits one of three player actions:
+//        - Pick a card → Apply it, end the draft, advance.
+//        - Skip       → No card applied, +1 to bankedRerolls, end the draft, advance.
+//        - Reroll     → Costs 1 banked reroll, redraws the SAME draft (different cards).
+//   6. Applies the picked card's effect via UpgradeCardSO.ApplyToAxis,
+//      records the pick in OwnedCardIds, fires MusicEvent.CardPicked.
 //   7. Transitions RunStateManager back to Running.
+//
+// Banked rerolls are run-scoped (cleared on RunStart). The bank cap is
+// configurable; default 3.
 //
 // If multiple level-ups stack (XP gem cluster pushed past two thresholds
 // in one frame), the queue handles them in FIFO order — one card screen
-// per level, no batching. This matches Vampire Survivors' UX.
-//
-// Lifecycle: drop on a [LevelUpCoordinator] empty GameObject in Game.unity.
-// Inspector wiring: assign the active UpgradePoolSO. PlayerStats is
-// lazy-discovered the first time it's needed (which is at card-pick time,
-// by which point the player has been spawned for sure).
+// per level, no batching.
 
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using CyberPickle.Core.Services;
 using CyberPickle.Gameplay.Audio;
 using CyberPickle.Gameplay.RunState;
 using CyberPickle.Gameplay.Stats;
+using CyberPickle.Gameplay.Weapons;
 
 namespace CyberPickle.Gameplay.Progression
 {
@@ -49,12 +52,19 @@ namespace CyberPickle.Gameplay.Progression
         [SerializeField] private UpgradePoolSO pool;
 
         [Header("Player Refs")]
-        [Tooltip("Player's PlayerStats component. Lazy-discovered at first level-up (the player isn't spawned yet at scene-load time, so we can't bind here in OnEnable). Inspector slot left available in case you want to wire explicitly for testing.")]
+        [Tooltip("Player's PlayerStats component. Lazy-discovered at first level-up. Inspector slot left available for explicit testing.")]
         [SerializeField] private PlayerStats playerStats;
 
         [Header("Draw Settings")]
-        [Tooltip("How many cards to show on each level-up. Default 3 (Vampire Survivors / Survivor.io standard).")]
-        [Min(1)] [SerializeField] private int cardsPerOffer = 3;
+        [Tooltip(
+            "OBSOLETE — kept for back-compat with existing scenes. Card count is now driven by " +
+            "RarityRollService.CardsVisibleForLuck (3 base, +1 per 50 Luck, cap 6) per CLAUDE.md " +
+            "design pillar. This inspector value is only used as a floor when Luck = 0.")]
+        [Min(1)] [SerializeField] private int cardsPerOfferFloor = 3;
+
+        [Header("Banked Rerolls")]
+        [Tooltip("Maximum number of banked rerolls. Skip-without-pick adds 1 to the bank; rerolls drain it. Run-scoped (resets on RunStart).")]
+        [Min(0)] [SerializeField] private int bankedRerollsCap = 3;
 
         [Header("Diagnostics")]
         [Tooltip("Log each level-up + card pick to the console.")]
@@ -62,23 +72,36 @@ namespace CyberPickle.Gameplay.Progression
 
         // ─── Public events for the UI layer ───────────────────────────────
 
-        /// <summary>Fires when the coordinator has drawn cards and the UI should display them. Argument is the cards to show.</summary>
-        public event Action<IReadOnlyList<UpgradeCardSO>> OnCardsDrawn;
+        /// <summary>Fires when the coordinator has drawn cards and the UI should display them.</summary>
+        public event Action<IReadOnlyList<DraftedCard>> OnCardsDrawn;
 
-        /// <summary>Fires after the picked card's modifiers have been applied. Argument is the picked card. Useful for animation hooks.</summary>
-        public event Action<UpgradeCardSO> OnCardApplied;
+        /// <summary>Fires after the picked card's effect has been applied. Useful for animation hooks.</summary>
+        public event Action<DraftedCard> OnCardApplied;
+
+        /// <summary>Fires when banked rerolls change (UI updates the Reroll button label).</summary>
+        public event Action<int> OnBankedRerollsChanged;
+
+        /// <summary>Current number of banked rerolls.</summary>
+        public int BankedRerolls { get; private set; }
+
+        /// <summary>Cap on banked rerolls (inspector-configured).</summary>
+        public int BankedRerollsCap => bankedRerollsCap;
 
         // ─── Public API for the UI to call back into ──────────────────────
 
         /// <summary>
-        /// Called by the UI when the player picks a card. Applies modifiers,
-        /// records ownership, resumes the run.
+        /// Player picked a card from the current draft. Applies it, records
+        /// ownership, resumes the run.
+        ///
+        /// For cards with <c>RequiresSlotSelection == true</c>, callers can
+        /// supply <paramref name="axisIndex"/>; pass -1 to fall back to
+        /// "first empty axis" auto-pick.
         /// </summary>
-        public void NotifyCardPicked(UpgradeCardSO card)
+        public void NotifyCardPicked(DraftedCard card, int axisIndex = -1)
         {
-            if (card == null)
+            if (!card.IsValid)
             {
-                Debug.LogError("[LevelUpCoordinator] NotifyCardPicked called with null card.");
+                Debug.LogError("[LevelUpCoordinator] NotifyCardPicked called with invalid card.");
                 ResumeRun();
                 return;
             }
@@ -90,18 +113,13 @@ namespace CyberPickle.Gameplay.Progression
                 return;
             }
 
-            // 2026-05-10 (Phase 5): replaced direct ApplyTo(stats) with the
-            // universal Apply dispatch that routes by CardType — StatModifier
-            // still flows through ApplyTo internally; LevelUp / RarityUp now
-            // route through WeaponLoadoutRuntime; PowerUp / SkillUnlock log
-            // their intent until M9 / M11 wire them.
-            var loadout = CyberPickle.Gameplay.Weapons.WeaponLoadoutRuntime.Instance;
-            string applyResult = card.Apply(playerStats, loadout);
-            _ownedCardIds.Add(card.cardId);
+            var loadout = WeaponLoadoutRuntime.Instance;
+            string applyResult = card.source.ApplyToAxis(playerStats, loadout, axisIndex, card.rolledElement, card.rolledRarity);
+            _ownedCardIds.Add(card.source.cardId);
             if (verbose)
-                Debug.Log($"[LevelUpCoordinator] Picked '{card.cardId}' ({card.cardType}): {applyResult}.");
+                Debug.Log($"[LevelUpCoordinator] Picked '{card.source.cardId}' ({card.source.cardType}, {card.rolledRarity}/{card.rolledElement}, axis={axisIndex}): {applyResult}.");
 
-            MusicEventBus.Fire(MusicEvent.CardPicked, card.cardId);
+            MusicEventBus.Fire(MusicEvent.CardPicked, card.source.cardId);
             OnCardApplied?.Invoke(card);
 
             ResumeRun();
@@ -109,22 +127,70 @@ namespace CyberPickle.Gameplay.Progression
         }
 
         /// <summary>
-        /// Called by the UI when the player banishes a card from the pool.
-        /// The card stays in this offer (the player still has to pick from
-        /// the remaining cards) but won't appear in future draws this run.
+        /// Player chose to skip this draft entirely (didn't pick any card).
+        /// Adds +1 to the banked-reroll counter (clamped at cap), ends the
+        /// current draft, advances. No card applied, no card recorded as owned.
         /// </summary>
-        public void NotifyCardBanished(UpgradeCardSO card)
+        public void NotifyDraftSkipped()
         {
-            if (card == null) return;
-            _banishedCardIds.Add(card.cardId);
-            MusicEventBus.Fire(MusicEvent.CardBanished, card.cardId);
-            if (verbose) Debug.Log($"[LevelUpCoordinator] Banished '{card.cardId}'.");
+            int previousBank = BankedRerolls;
+            BankedRerolls = Mathf.Min(bankedRerollsCap, BankedRerolls + 1);
+
+            if (verbose)
+            {
+                if (BankedRerolls > previousBank)
+                    Debug.Log($"[LevelUpCoordinator] Draft skipped. Banked rerolls: {previousBank} → {BankedRerolls}.");
+                else
+                    Debug.Log($"[LevelUpCoordinator] Draft skipped. Bank already at cap ({bankedRerollsCap}); +1 reroll discarded.");
+            }
+
+            OnBankedRerollsChanged?.Invoke(BankedRerolls);
+            MusicEventBus.Fire(MusicEvent.CardSkipped, null);
+
+            ResumeRun();
+            ProcessNextPendingLevelUp();
         }
 
-        /// <summary>Diagnostic accessor. UI uses to grey-out already-owned cards if relevant.</summary>
-        public IReadOnlyCollection<string> OwnedCardIds => _ownedCardIds;
+        /// <summary>
+        /// Player spent 1 banked reroll to redraw the current draft.
+        /// Returns the new card list (also fires OnCardsDrawn so the UI can
+        /// just listen to the event). Returns an empty list if no banked
+        /// rerolls available — UI should disable the Reroll button when
+        /// BankedRerolls == 0.
+        /// </summary>
+        public IReadOnlyList<DraftedCard> NotifyRerollRequested()
+        {
+            if (BankedRerolls <= 0)
+            {
+                if (verbose) Debug.Log("[LevelUpCoordinator] Reroll requested but no banked rerolls available.");
+                return Array.Empty<DraftedCard>();
+            }
 
-        /// <summary>Diagnostic accessor. UI uses to grey-out banished cards.</summary>
+            BankedRerolls--;
+            OnBankedRerollsChanged?.Invoke(BankedRerolls);
+
+            if (verbose) Debug.Log($"[LevelUpCoordinator] Reroll spent. Banked rerolls: {BankedRerolls + 1} → {BankedRerolls}. Redrawing draft.");
+
+            // Re-draw using current loadout + Luck.
+            float luck = EnsurePlayerStats() ? playerStats.Get(PlayerStatType.Luck) : 0f;
+            int count = Mathf.Max(cardsPerOfferFloor, RarityRollService.CardsVisibleForLuck(luck));
+            var loadout = WeaponLoadoutRuntime.Instance;
+            var cards = pool.DrawCards(count, luck, loadout, _banishedCardIds, _ownedCardIds);
+
+            OnCardsDrawn?.Invoke(cards);
+            return cards;
+        }
+
+        /// <summary>Banish a card from the rest-of-run pool. Doesn't end the draft.</summary>
+        public void NotifyCardBanished(DraftedCard card)
+        {
+            if (!card.IsValid) return;
+            _banishedCardIds.Add(card.source.cardId);
+            MusicEventBus.Fire(MusicEvent.CardBanished, card.source.cardId);
+            if (verbose) Debug.Log($"[LevelUpCoordinator] Banished '{card.source.cardId}'.");
+        }
+
+        public IReadOnlyCollection<string> OwnedCardIds => _ownedCardIds;
         public IReadOnlyCollection<string> BanishedCardIds => _banishedCardIds;
 
         // ─── Internal state ───────────────────────────────────────────────
@@ -138,12 +204,6 @@ namespace CyberPickle.Gameplay.Progression
 
         private void OnEnable()
         {
-            // Subscribe to the process-global music bus. This is the ONLY
-            // listener we wire here because the bus is the only source we
-            // can rely on to be alive at OnEnable time — components like
-            // PlayerXPBridge don't exist yet (the player is spawned by
-            // GameSceneBootstrap.Start, AFTER all OnEnables). PlayerStats
-            // is lazy-discovered when needed (see EnsurePlayerStats).
             MusicEventBus.OnEvent += HandleMusicEvent;
         }
 
@@ -157,16 +217,6 @@ namespace CyberPickle.Gameplay.Progression
             switch (type)
             {
                 case MusicEvent.RunStart:
-                    // The player is spawned and PlayerStats is initialized BEFORE
-                    // RunStateManager.TransitionTo(Running) fires this event (see
-                    // GameSceneBootstrap.SpawnSelectedCharacter — InitializePlayerStats
-                    // is called before TransitionTo). So by the time we land here,
-                    // PlayerStats exists and is ready to read.
-                    //
-                    // Doing the find here means level-up events later are
-                    // free of any FindFirstObjectByType cost. The find is O(n)
-                    // in scene size — fine to pay once per run, expensive to
-                    // repeat per level-up.
                     CachePlayerRefs();
                     ResetRunScopedState();
                     break;
@@ -178,46 +228,31 @@ namespace CyberPickle.Gameplay.Progression
             }
         }
 
-        /// <summary>
-        /// One-time per-run cache of the player components. Honors any
-        /// inspector-wired reference (don't overwrite if the user pre-bound).
-        /// Logs an error if PlayerStats is somehow still missing — would
-        /// indicate the player failed to spawn or the bootstrap mis-ordered
-        /// stat init vs. RunStateManager transition.
-        /// </summary>
         private void CachePlayerRefs()
         {
             if (playerStats == null)
                 playerStats = FindFirstObjectByType<PlayerStats>();
 
             if (playerStats == null)
-                Debug.LogError("[LevelUpCoordinator] CachePlayerRefs: no PlayerStats found at RunStart. Player did not spawn correctly.");
+                Debug.LogError("[LevelUpCoordinator] CachePlayerRefs: no PlayerStats found at RunStart.");
             else if (verbose)
                 Debug.Log($"[LevelUpCoordinator] Cached PlayerStats on '{playerStats.name}' at RunStart.");
         }
 
-        /// <summary>
-        /// Resets per-run state. Called on RunStart so a Try Again from the
-        /// results screen starts with a fresh banish list, fresh owned-cards
-        /// list, and an empty pending-level queue. Without this, a previous
-        /// run's banishments could carry over (currently masked by the fact
-        /// that scene-bound managers are recreated on scene reload, but
-        /// resetting here removes that dependency).
-        /// </summary>
         private void ResetRunScopedState()
         {
             _ownedCardIds.Clear();
             _banishedCardIds.Clear();
             _pendingLevels.Clear();
             _screenActive = false;
+
+            if (BankedRerolls != 0)
+            {
+                BankedRerolls = 0;
+                OnBankedRerollsChanged?.Invoke(0);
+            }
         }
 
-        /// <summary>
-        /// Defensive fallback in case a level-up somehow fires before RunStart
-        /// (direct-Play testing, time-travel via debug command, etc.). Returns
-        /// true if PlayerStats is now valid; false if we genuinely can't find it.
-        /// In the normal flow this is a no-op since CachePlayerRefs already ran.
-        /// </summary>
         private bool EnsurePlayerStats()
         {
             if (playerStats != null) return true;
@@ -233,9 +268,6 @@ namespace CyberPickle.Gameplay.Progression
             if (verbose)
                 Debug.Log($"[LevelUpCoordinator] Level-up queued: {newLevel}. Queue depth = {_pendingLevels.Count}.");
 
-            // If the screen isn't currently up, start processing. If it IS
-            // up, this level-up is queued and processed when the current
-            // pick completes.
             if (!_screenActive)
                 ProcessNextPendingLevelUp();
         }
@@ -255,15 +287,15 @@ namespace CyberPickle.Gameplay.Progression
                 return;
             }
 
-            // Pause the run.
             if (RunStateManager.Instance != null)
                 RunStateManager.Instance.TransitionTo(RunStatePhase.LevelUpPaused);
 
-            // Draw cards. Pull Luck for rarity weighting; tolerate missing
-            // PlayerStats (would only happen on a direct-Play test that
-            // skipped the bootstrap) and just use luck=0.
+            // Card count: Luck-driven via RarityRollService.CardsVisibleForLuck.
+            // Floor at the inspector-configured count for legacy scenes.
             float luck = EnsurePlayerStats() ? playerStats.Get(PlayerStatType.Luck) : 0f;
-            var cards = pool.DrawCards(cardsPerOffer, luck, _banishedCardIds, _ownedCardIds);
+            int count = Mathf.Max(cardsPerOfferFloor, RarityRollService.CardsVisibleForLuck(luck));
+            var loadout = WeaponLoadoutRuntime.Instance;
+            var cards = pool.DrawCards(count, luck, loadout, _banishedCardIds, _ownedCardIds);
 
             if (cards.Count == 0)
             {
@@ -275,8 +307,16 @@ namespace CyberPickle.Gameplay.Progression
 
             if (verbose)
             {
-                string cardList = string.Join(", ", cards.ConvertAll(c => $"{c.cardId}({c.rarity})"));
-                Debug.Log($"[LevelUpCoordinator] Drew {cards.Count} cards for level {newLevel}: {cardList}");
+                var sb = new System.Text.StringBuilder();
+                for (int i = 0; i < cards.Count; i++)
+                {
+                    if (i > 0) sb.Append(", ");
+                    var d = cards[i];
+                    sb.Append($"{d.source.cardId}({d.rolledRarity}");
+                    if (d.rolledElement != Core.ElementId.None) sb.Append($"/{d.rolledElement}");
+                    sb.Append(')');
+                }
+                Debug.Log($"[LevelUpCoordinator] Drew {cards.Count} cards for level {newLevel}: {sb}");
             }
 
             _screenActive = true;

--- a/Assets/_CyberPickle/Code/Gameplay/Progression/UpgradeCardSO.cs
+++ b/Assets/_CyberPickle/Code/Gameplay/Progression/UpgradeCardSO.cs
@@ -36,31 +36,49 @@ namespace CyberPickle.Gameplay.Progression
     /// <summary>
     /// What kind of card this is. Drives how it's applied when picked AND
     /// how it's weighted in the level-up draft pool. Per <c>weapon_rarity_v1.md</c>
-    /// §3 Path B, the draft pool offers a mix of types (50% LevelUp / 25%
-    /// PowerUp / 15% RarityUp / 10% SkillUnlock as project defaults).
+    /// §3 Path B, the draft pool offers a mix of types and the loadout-aware
+    /// filter in <see cref="UpgradePoolSO"/> hides any card that wouldn't
+    /// land on a valid target (e.g., NewWeapon when all weapon slots are
+    /// full, LevelUpWeapon when the target weapon isn't equipped).
     ///
     /// Stable byte values — DO NOT renumber. Existing card .asset files
     /// default to <see cref="StatModifier"/> (value 0).
+    ///
+    /// 2026-05-11 (M8 step 2): added NewWeapon / LevelUpPowerUp /
+    /// RarityUpPowerUp. Renamed LevelUp → LevelUpWeapon and RarityUp →
+    /// RarityUpWeapon for clarity (byte values unchanged so existing
+    /// assets continue to deserialize correctly). PowerUp (byte 2) was a
+    /// stub; repurposed as NewPowerUp now that PowerUpData has a real
+    /// shape.
     /// </summary>
     public enum CardType : byte
     {
-        /// <summary>Applies <c>modifiers[]</c> via <c>PlayerStats.AddModifier</c>. The original card behavior; default for back-compat with existing assets.</summary>
+        /// <summary>Applies <c>modifiers[]</c> via <c>PlayerStats.AddModifier</c>. The "Buff" card type — global stat boost, no slot picker. Default for back-compat with existing assets.</summary>
         StatModifier = 0,
 
-        /// <summary>Levels a specific weapon by 1 (or adds it to the loadout at L1 if not yet equipped). References <c>targetWeaponData</c>.</summary>
-        LevelUp = 1,
+        /// <summary>Levels a specific equipped weapon by 1. References <c>targetWeaponData</c>. Filtered out by the pool if the target isn't equipped or already at L5 (use Evolve for L5 → Evolved).</summary>
+        LevelUpWeapon = 1,
 
-        /// <summary>Applies a power-up of a specific type+element to a weapon. References <c>targetPowerUpId</c>. M9 work — currently a stub that logs only.</summary>
-        PowerUp = 2,
+        /// <summary>Adds a power-up to a chosen empty axis. Slot-picker required. References <c>targetPowerUpData</c>. Element + Rarity rolled at draft time onto the <c>DraftedCard</c> wrapper.</summary>
+        NewPowerUp = 2,
 
-        /// <summary>Bumps a specific weapon's rarity by +1 tier (clamped at Legendary). References <c>targetWeaponData</c>.</summary>
-        RarityUp = 3,
+        /// <summary>Bumps a specific equipped weapon's rarity by +1 tier (clamped at Legendary). References <c>targetWeaponData</c>. Filtered out by the pool if the target isn't equipped or already Legendary.</summary>
+        RarityUpWeapon = 3,
 
         /// <summary>Activates a run-scoped skill power (Banish, Lock, Forge access, etc.). References <c>targetSkillId</c>. M11 work — currently a stub that logs only.</summary>
         SkillUnlock = 4,
 
         /// <summary>Reserved — purely cosmetic cards (skins, palette swaps, kill-confirms). Never affects gameplay.</summary>
         Cosmetic = 5,
+
+        /// <summary>Adds a new weapon to a chosen empty axis. Slot-picker required. References <c>targetWeaponData</c>. Filtered out by the pool if all weapon axes are full. Rarity rolled at draft time.</summary>
+        NewWeapon = 6,
+
+        /// <summary>Levels a specific equipped power-up by 1. References <c>targetPowerUpData</c>. Filtered out by the pool if the target isn't equipped or already at L5.</summary>
+        LevelUpPowerUp = 7,
+
+        /// <summary>Bumps a specific equipped power-up's rarity by +1 tier. References <c>targetPowerUpData</c>. Filtered out by the pool if the target isn't equipped or already Legendary.</summary>
+        RarityUpPowerUp = 8,
     }
 
     [CreateAssetMenu(menuName = "CyberPickle/Progression/Upgrade Card", fileName = "Card_")]
@@ -94,14 +112,15 @@ namespace CyberPickle.Gameplay.Progression
         [Tooltip("Determines how this card is applied when picked. Default is StatModifier (the original behavior — applies the modifiers[] array). New types: LevelUp / RarityUp target a specific weapon; PowerUp / SkillUnlock are M9-M11 stubs that currently log only.")]
         public CardType cardType = CardType.StatModifier;
 
-        [Header("Targeting (used by LevelUp / RarityUp)")]
-        [Tooltip("Weapon this card affects. REQUIRED for LevelUp and RarityUp card types. LevelUp adds the weapon at L1 if not equipped, else levels it by 1. RarityUp bumps the equipped weapon's rarity by 1; if the weapon isn't equipped, the card is a no-op (won't appear in pool — see UpgradePoolSO eligibility filter).")]
+        [Header("Targeting — Weapon")]
+        [Tooltip("Weapon this card affects. REQUIRED for NewWeapon / LevelUpWeapon / RarityUpWeapon. The pool filter ensures the card only appears when its target is appropriate (equipped & below cap for level/rarity-up, empty axis available for new-weapon).")]
         public WeaponData targetWeaponData;
 
-        [Header("Targeting (M9-M11 stubs — wire when those systems land)")]
-        [Tooltip("Power-up identifier — used by CardType.PowerUp. M9 work; for now this just logs the intent.")]
-        public string targetPowerUpId;
+        [Header("Targeting — Power-up")]
+        [Tooltip("Power-up this card affects. REQUIRED for NewPowerUp / LevelUpPowerUp / RarityUpPowerUp. For NewPowerUp, the rolled element is set at draft time and lives on the DraftedCard wrapper, not on the asset.")]
+        public PowerUpData targetPowerUpData;
 
+        [Header("Targeting — Skill (M11 stub)")]
         [Tooltip("Skill node identifier — used by CardType.SkillUnlock. M11 work; for now this just logs the intent.")]
         public string targetSkillId;
 
@@ -176,15 +195,36 @@ namespace CyberPickle.Gameplay.Progression
         /// <summary>
         /// Universal apply dispatch. Routes the card's effect based on
         /// <see cref="cardType"/>. Caller passes both PlayerStats (for
-        /// stat modifiers) and WeaponLoadoutRuntime (for level/rarity-up
+        /// stat modifiers) and WeaponLoadoutRuntime (for weapon / power-up
         /// targeting); either may be null for cards that don't need it.
         ///
+        /// For cards with <c>RequiresSlotSelection == true</c> (NewWeapon,
+        /// NewPowerUp), this method picks the FIRST EMPTY axis. Use
+        /// <see cref="ApplyToAxis"/> for the slot-picker UI flow where
+        /// the player chose a specific axis.
+        ///
+        /// For NewPowerUp specifically, the rolled element is needed —
+        /// callers without a rolled element (test code, retro-applies)
+        /// pass <see cref="ElementId.None"/>. Production callers go
+        /// through <see cref="ApplyToAxis"/> with the DraftedCard's value.
+        ///
         /// Returns a short description of what was applied, useful for
-        /// the level-up confirmation log and analytics. Empty string
-        /// means "nothing applied" (e.g., card targeted a weapon that
-        /// isn't equipped, or referenced a stub system).
+        /// the level-up confirmation log and analytics.
         /// </summary>
         public string Apply(PlayerStats stats, WeaponLoadoutRuntime loadout)
+            => ApplyToAxis(stats, loadout, axisIndex: -1, rolledElement: ElementId.None, rolledRarity: rarity);
+
+        /// <summary>
+        /// Slot-picker-aware apply. Used by the level-up screen flow when
+        /// the card kind requires the player to pick an axis (NewWeapon,
+        /// NewPowerUp). Pre-targeted cards (LevelUpWeapon, RarityUpWeapon,
+        /// LevelUpPowerUp, RarityUpPowerUp, StatModifier, SkillUnlock,
+        /// Cosmetic) ignore <paramref name="axisIndex"/>.
+        ///
+        /// <paramref name="axisIndex"/> &lt; 0 means "first empty axis"
+        /// (auto-pick fallback for non-UI callers).
+        /// </summary>
+        public string ApplyToAxis(PlayerStats stats, WeaponLoadoutRuntime loadout, int axisIndex, ElementId rolledElement, Rarity rolledRarity)
         {
             switch (cardType)
             {
@@ -194,57 +234,75 @@ namespace CyberPickle.Gameplay.Progression
                     return applied > 0 ? $"applied {applied} modifier(s)" : "no modifiers";
                 }
 
-                case CardType.LevelUp:
+                case CardType.NewWeapon:
+                {
+                    if (loadout == null || targetWeaponData == null) return "no target weapon";
+                    bool ok = axisIndex >= 0
+                        ? loadout.TryAddWeaponAt(axisIndex, targetWeaponData, rolledRarity, out var addedAt)
+                        : loadout.TryAddWeapon(targetWeaponData, rolledRarity, out addedAt);
+                    return ok ? $"added '{addedAt.WeaponId}' to axis {addedAt.slotIndex} at {rolledRarity}"
+                              : "no empty weapon axis";
+                }
+
+                case CardType.LevelUpWeapon:
                 {
                     if (loadout == null || targetWeaponData == null) return "no target weapon";
                     var existing = loadout.FindByWeaponData(targetWeaponData);
-                    if (existing == null)
-                    {
-                        // Not yet equipped — add to loadout at Common (the
-                        // first-roll could be deferred to RarityRollService
-                        // with player Luck if we want richer behavior; for
-                        // now LevelUp adds at Common to keep semantics simple).
-                        if (loadout.TryAddWeapon(targetWeaponData, Rarity.Common, out var added))
-                            return $"added '{added.WeaponId}' to loadout (slot {added.slotIndex})";
-                        return "loadout full — add failed";
-                    }
-                    if (existing.level >= 5) return $"'{existing.WeaponId}' already at L5 (use evolution)";
+                    if (existing == null) return "weapon not equipped (filter bug)";
+                    if (existing.level >= 5) return $"'{existing.WeaponId}' already at L5";
                     bool ok = loadout.LevelUpWeapon(existing.slotIndex);
                     return ok ? $"'{existing.WeaponId}' L{existing.level - 1} → L{existing.level}" : "level-up failed";
                 }
 
-                case CardType.RarityUp:
+                case CardType.RarityUpWeapon:
                 {
                     if (loadout == null || targetWeaponData == null) return "no target weapon";
                     var existing = loadout.FindByWeaponData(targetWeaponData);
-                    if (existing == null) return "weapon not equipped";
+                    if (existing == null) return "weapon not equipped (filter bug)";
                     if (existing.rarity == Rarity.Legendary) return $"'{existing.WeaponId}' already Legendary";
                     var oldRarity = existing.rarity;
                     bool ok = loadout.UpgradeRarity(existing.slotIndex, 1);
                     return ok ? $"'{existing.WeaponId}' rarity {oldRarity} → {existing.rarity}" : "rarity-up failed";
                 }
 
-                case CardType.PowerUp:
+                case CardType.NewPowerUp:
                 {
-                    // M9 stub — when PowerUpData lands, this will:
-                    //   1. Look up PowerUpData by targetPowerUpId
-                    //   2. Apply its mechanical effect to stats / loadout
-                    //   3. If it triggers an evolution, call loadout.EvolveWeapon
-                    //      and lock in the power-up's element
-                    Debug.Log($"[UpgradeCardSO] PowerUp card '{cardId}' picked (target='{targetPowerUpId}'). Stub — M9 will implement.");
-                    return $"[stub] power-up '{targetPowerUpId}'";
+                    if (loadout == null || targetPowerUpData == null) return "no target power-up";
+                    bool ok = axisIndex >= 0
+                        ? loadout.TryAddPowerUpAt(axisIndex, targetPowerUpData, rolledElement, rolledRarity, out var addedPU)
+                        : loadout.TryAddPowerUp(targetPowerUpData, rolledElement, rolledRarity, out addedPU);
+                    return ok ? $"added power-up '{addedPU.PowerUpId}' to axis {addedPU.axisIndex} at {rolledRarity}/{rolledElement}"
+                              : "no empty power-up axis";
+                }
+
+                case CardType.LevelUpPowerUp:
+                {
+                    if (loadout == null || targetPowerUpData == null) return "no target power-up";
+                    var existing = loadout.FindByPowerUpData(targetPowerUpData);
+                    if (existing == null) return "power-up not equipped (filter bug)";
+                    if (existing.level >= 5) return $"'{existing.PowerUpId}' already at L5";
+                    bool ok = loadout.LevelUpPowerUp(existing.axisIndex);
+                    return ok ? $"'{existing.PowerUpId}' L{existing.level - 1} → L{existing.level}" : "level-up failed";
+                }
+
+                case CardType.RarityUpPowerUp:
+                {
+                    if (loadout == null || targetPowerUpData == null) return "no target power-up";
+                    var existing = loadout.FindByPowerUpData(targetPowerUpData);
+                    if (existing == null) return "power-up not equipped (filter bug)";
+                    if (existing.rarity == Rarity.Legendary) return $"'{existing.PowerUpId}' already Legendary";
+                    var oldRarity = existing.rarity;
+                    bool ok = loadout.UpgradePowerUpRarity(existing.axisIndex, 1);
+                    return ok ? $"'{existing.PowerUpId}' rarity {oldRarity} → {existing.rarity}" : "rarity-up failed";
                 }
 
                 case CardType.SkillUnlock:
                 {
-                    // M11 stub — when SkillTreeAllocation lands, this will
-                    // activate the named run-power (Banish, Lock, Forge access).
                     Debug.Log($"[UpgradeCardSO] SkillUnlock card '{cardId}' picked (target='{targetSkillId}'). Stub — M11 will implement.");
                     return $"[stub] skill '{targetSkillId}'";
                 }
 
                 case CardType.Cosmetic:
-                    // Cosmetics never affect gameplay.
                     return "cosmetic — no gameplay effect";
 
                 default:

--- a/Assets/_CyberPickle/Code/Gameplay/Progression/UpgradePoolSO.cs
+++ b/Assets/_CyberPickle/Code/Gameplay/Progression/UpgradePoolSO.cs
@@ -2,16 +2,30 @@
 // Namespace: CyberPickle.Gameplay.Progression
 //
 // Container for the set of UpgradeCardSO assets the player can be offered
-// during a run. The level-up coordinator queries this pool for the 3 cards
+// during a run. The level-up coordinator queries this pool for the cards
 // to display each level-up.
 //
-// Drawing rules:
-//   - Filtered by banished cards (per-run banish list, applied via Banish
-//     button on level-up screen — wired in M9 economy work)
-//   - Filtered by prerequisite cards (a card with prereqs only appears
-//     once all listed cards are owned)
-//   - Weighted by rarity, with Luck stat modulating the weights toward
-//     higher rarities
+// Drawing rules (post-M8 step 2):
+//   - LOADOUT-AWARE FILTER (the new rule): cards are filtered by the
+//     player's current loadout state. NewWeapon cards only appear when
+//     a weapon axis is empty; LevelUpWeapon cards only appear when their
+//     target weapon is equipped and below L5; same for power-up variants.
+//     This is the user's "only show what's relevant" rule from chat
+//     2026-05-11 — once your weapons are full, the pool stops offering
+//     new ones and shifts entirely to upgrade cards.
+//   - Banished cards (per-run banish list, applied via Banish button on
+//     level-up screen)
+//   - Prerequisites (a card with prereqs only appears once all listed
+//     cards are owned)
+//   - Weighted by rarity, with Luck modulating the weights toward
+//     higher rarities (computed by RarityRollService elsewhere; kept here
+//     because the pool already had local weight defaults)
+//
+// Output: List<DraftedCard>. The DraftedCard wrapper carries the rolled
+// rarity (so re-applies are deterministic) AND the rolled element (only
+// meaningful for NewPowerUp cards — others use ElementId.None). The
+// element roll is uniform across the 7 element identities — Fire,
+// Lightning, Ice, Earth, Plasma, Light, Dark.
 //
 // Why a separate pool SO instead of "all UpgradeCardSO assets in the
 // project": pools are scoped per-character / per-run / per-level. Pik's
@@ -22,6 +36,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using CyberPickle.Core;
+using CyberPickle.Gameplay.Weapons;
 
 namespace CyberPickle.Gameplay.Progression
 {
@@ -45,47 +60,71 @@ namespace CyberPickle.Gameplay.Progression
         [Min(0f)] public float weightLegendary = 1f;
 
         [Header("Card Type Weights (project defaults per weapon_rarity_v1.md §3 Path B)")]
-        [Tooltip("Relative draw weight for StatModifier cards (the original card type — applies StatModifier[] via PlayerStats). Default low because most stat-only effects are captured by per-weapon LevelUp cards now.")]
+        [Tooltip("Relative weight for StatModifier (Buff) cards. Always eligible — no loadout-state filter.")]
         [Min(0f)] public float weightTypeStatModifier = 30f;
 
-        [Tooltip("Relative draw weight for LevelUp cards. Highest by default — leveling weapons is the bread-and-butter of the draft.")]
-        [Min(0f)] public float weightTypeLevelUp = 50f;
+        [Tooltip("Relative weight for LevelUpWeapon cards. Filtered to only equipped weapons below L5. The bread-and-butter of the draft once weapons are slotted.")]
+        [Min(0f)] public float weightTypeLevelUpWeapon = 50f;
 
-        [Tooltip("Relative draw weight for PowerUp cards. M9 work; weight is set but cards typed PowerUp are stubs until then.")]
-        [Min(0f)] public float weightTypePowerUp = 25f;
+        [Tooltip("Relative weight for NewPowerUp cards (replaces the old PowerUp stub). Filtered to require an empty power-up axis.")]
+        [Min(0f)] public float weightTypeNewPowerUp = 25f;
 
-        [Tooltip("Relative draw weight for RarityUp cards — the per-shot damage scalar bumper.")]
-        [Min(0f)] public float weightTypeRarityUp = 15f;
+        [Tooltip("Relative weight for RarityUpWeapon cards. Filtered to equipped weapons below Legendary.")]
+        [Min(0f)] public float weightTypeRarityUpWeapon = 15f;
 
-        [Tooltip("Relative draw weight for SkillUnlock cards. M11 work; weight is set but cards typed SkillUnlock are stubs until then.")]
+        [Tooltip("Relative weight for SkillUnlock cards. M11 work; cards typed SkillUnlock are stubs until then.")]
         [Min(0f)] public float weightTypeSkillUnlock = 10f;
 
-        [Tooltip("Relative draw weight for Cosmetic cards. 0 by default (cosmetics don't appear in level-up drafts; they're shop-only).")]
+        [Tooltip("Relative weight for Cosmetic cards. 0 by default (cosmetics don't appear in level-up drafts; they're shop-only).")]
         [Min(0f)] public float weightTypeCosmetic = 0f;
+
+        [Tooltip("Relative weight for NewWeapon cards. Filtered to require an empty weapon axis. Once axes fill up, the pool stops offering these and tilts toward upgrade cards.")]
+        [Min(0f)] public float weightTypeNewWeapon = 30f;
+
+        [Tooltip("Relative weight for LevelUpPowerUp cards. Filtered to equipped power-ups below L5.")]
+        [Min(0f)] public float weightTypeLevelUpPowerUp = 30f;
+
+        [Tooltip("Relative weight for RarityUpPowerUp cards. Filtered to equipped power-ups below Legendary.")]
+        [Min(0f)] public float weightTypeRarityUpPowerUp = 12f;
 
         [Header("Luck Modulation")]
         [Tooltip("How aggressively Luck shifts weight from Common→Legendary. At Luck=0 weights are unchanged. At Luck=100 + this multiplier 0.5, weights for Rare/Epic/Legendary are 50% higher and Common 50% lower (tunable). Ship safely below 1 to avoid game-breaking-rarity-flooding.")]
         [Range(0f, 1f)] public float luckShiftPerHundred = 0.5f;
 
+        // Element pool used when rolling a NewPowerUp card's element. We
+        // skip ElementId.None — neutral power-ups don't make sense (their
+        // whole point is to confer an element to a weapon).
+        private static readonly ElementId[] ROLLABLE_ELEMENTS = new[]
+        {
+            ElementId.Fire, ElementId.Lightning, ElementId.Ice, ElementId.Earth,
+            ElementId.Plasma, ElementId.Light, ElementId.Dark,
+        };
+
         // ─── Drawing API ──────────────────────────────────────────────────
 
         /// <summary>
         /// Draws up to <paramref name="count"/> distinct cards from the pool,
-        /// filtered by the supplied predicates and weighted by rarity (modulated
-        /// by Luck). Returns fewer than <paramref name="count"/> cards if the
-        /// pool can't satisfy the request (e.g., everything banished, low pool size).
+        /// filtered by current loadout state + banish + prerequisites, and
+        /// weighted by rarity (Luck-modulated). Returns fewer than
+        /// <paramref name="count"/> cards if the filtered pool is too small.
+        ///
+        /// Each returned <see cref="DraftedCard"/> carries the rolled rarity
+        /// (used by Apply when committing the card) AND the rolled element
+        /// (only meaningful for NewPowerUp cards).
         /// </summary>
-        /// <param name="count">How many cards to draw (typically 3).</param>
-        /// <param name="luck">Player Luck stat. 0+ — modulates rarity weights.</param>
+        /// <param name="count">How many cards to draw.</param>
+        /// <param name="luck">Player Luck stat — modulates rarity weights.</param>
+        /// <param name="loadout">Current loadout — used to filter cards by axis state. May be null (all loadout-dependent cards then filtered out conservatively).</param>
         /// <param name="banishedCardIds">CardIds banished this run; will be skipped.</param>
         /// <param name="ownedCardIds">CardIds the player already has; used for prerequisite checks.</param>
-        public List<UpgradeCardSO> DrawCards(
+        public List<DraftedCard> DrawCards(
             int count,
             float luck,
+            WeaponLoadoutRuntime loadout,
             HashSet<string> banishedCardIds,
             HashSet<string> ownedCardIds)
         {
-            var result = new List<UpgradeCardSO>(count);
+            var result = new List<DraftedCard>(count);
             if (cards == null || cards.Length == 0) return result;
 
             // Build the eligible list once (filters applied).
@@ -96,6 +135,7 @@ namespace CyberPickle.Gameplay.Progression
                 if (c == null) continue;
                 if (banishedCardIds != null && banishedCardIds.Contains(c.cardId)) continue;
                 if (!PrerequisitesMet(c, ownedCardIds)) continue;
+                if (!IsEligibleForLoadout(c, loadout)) continue;
                 eligible.Add(c);
             }
 
@@ -129,14 +169,92 @@ namespace CyberPickle.Gameplay.Progression
                     }
                 }
 
-                result.Add(eligible[picked]);
+                var pickedSo = eligible[picked];
+                var drafted = new DraftedCard
+                {
+                    source        = pickedSo,
+                    rolledRarity  = pickedSo.rarity, // authored rarity is the roll for now; future: re-roll on draft
+                    rolledElement = pickedSo.cardType == CardType.NewPowerUp
+                                       ? ROLLABLE_ELEMENTS[Random.Range(0, ROLLABLE_ELEMENTS.Length)]
+                                       : ElementId.None,
+                };
+                result.Add(drafted);
+
                 totalWeight -= weights[picked];
                 eligible.RemoveAt(picked);
-                // O(n) array shift; weights array kept in sync via swap-and-pop.
-                weights[picked] = weights[eligible.Count];
+                weights[picked] = weights[eligible.Count]; // O(1) swap-and-pop
             }
 
             return result;
+        }
+
+        // ─── Eligibility — loadout-aware filter ──────────────────────────
+
+        /// <summary>
+        /// Per-type filter: returns true if the card would land on a valid
+        /// target given the current loadout. Implements the user's "only
+        /// show what's relevant" rule.
+        /// </summary>
+        private static bool IsEligibleForLoadout(UpgradeCardSO card, WeaponLoadoutRuntime loadout)
+        {
+            // Without a loadout reference (e.g., test code), everything that
+            // doesn't strictly require one passes through. Loadout-dependent
+            // types are conservatively rejected.
+            if (loadout == null)
+            {
+                return card.cardType == CardType.StatModifier
+                    || card.cardType == CardType.SkillUnlock
+                    || card.cardType == CardType.Cosmetic;
+            }
+
+            switch (card.cardType)
+            {
+                case CardType.StatModifier:
+                case CardType.SkillUnlock:
+                case CardType.Cosmetic:
+                    return true; // no loadout dependency
+
+                case CardType.NewWeapon:
+                    return card.targetWeaponData != null
+                        && !loadout.AreWeaponSlotsFull
+                        && loadout.FindByWeaponData(card.targetWeaponData) == null; // not already equipped
+
+                case CardType.LevelUpWeapon:
+                {
+                    if (card.targetWeaponData == null) return false;
+                    var w = loadout.FindByWeaponData(card.targetWeaponData);
+                    return w != null && w.level < 5;
+                }
+
+                case CardType.RarityUpWeapon:
+                {
+                    if (card.targetWeaponData == null) return false;
+                    var w = loadout.FindByWeaponData(card.targetWeaponData);
+                    return w != null && w.rarity != Rarity.Legendary;
+                }
+
+                case CardType.NewPowerUp:
+                    return card.targetPowerUpData != null
+                        && !loadout.ArePowerUpSlotsFull
+                        && loadout.FindByPowerUpData(card.targetPowerUpData) == null;
+
+                case CardType.LevelUpPowerUp:
+                {
+                    if (card.targetPowerUpData == null) return false;
+                    var p = loadout.FindByPowerUpData(card.targetPowerUpData);
+                    return p != null && p.level < 5;
+                }
+
+                case CardType.RarityUpPowerUp:
+                {
+                    if (card.targetPowerUpData == null) return false;
+                    var p = loadout.FindByPowerUpData(card.targetPowerUpData);
+                    return p != null && p.rarity != Rarity.Legendary;
+                }
+
+                default:
+                    return false;
+            }
         }
 
         // ─── Internals ────────────────────────────────────────────────────
@@ -154,13 +272,12 @@ namespace CyberPickle.Gameplay.Progression
             };
 
             // Luck modulation: shift weight from Common toward higher rarities.
-            // shiftAmount in [0..1]; lower rarities scale down, higher scale up.
             float shiftAmount = Mathf.Clamp01((luck * 0.01f) * luckShiftPerHundred);
             float multiplier = rarity switch
             {
                 Rarity.Common    => 1f - shiftAmount,
-                Rarity.Uncommon  => 1f - shiftAmount * 0.4f,  // slightly down
-                Rarity.Rare      => 1f + shiftAmount * 0.5f,  // up
+                Rarity.Uncommon  => 1f - shiftAmount * 0.4f,
+                Rarity.Rare      => 1f + shiftAmount * 0.5f,
                 Rarity.Epic      => 1f + shiftAmount * 1.0f,
                 Rarity.Legendary => 1f + shiftAmount * 1.5f,
                 _                => 1f,
@@ -169,21 +286,18 @@ namespace CyberPickle.Gameplay.Progression
             return Mathf.Max(0f, baseWeight * multiplier);
         }
 
-        /// <summary>
-        /// Lookup the per-card-type weight from this pool. Multiplied
-        /// against the rarity weight to produce the final draw weight
-        /// per card. See header for the project default distribution
-        /// (50/30/25/15/10/0 across LevelUp/StatMod/PowerUp/RarityUp/SkillUnlock/Cosmetic).
-        /// </summary>
         private float TypeWeight(CardType type) => type switch
         {
-            CardType.StatModifier => weightTypeStatModifier,
-            CardType.LevelUp      => weightTypeLevelUp,
-            CardType.PowerUp      => weightTypePowerUp,
-            CardType.RarityUp     => weightTypeRarityUp,
-            CardType.SkillUnlock  => weightTypeSkillUnlock,
-            CardType.Cosmetic     => weightTypeCosmetic,
-            _                     => 0f,
+            CardType.StatModifier    => weightTypeStatModifier,
+            CardType.LevelUpWeapon   => weightTypeLevelUpWeapon,
+            CardType.NewPowerUp      => weightTypeNewPowerUp,
+            CardType.RarityUpWeapon  => weightTypeRarityUpWeapon,
+            CardType.SkillUnlock     => weightTypeSkillUnlock,
+            CardType.Cosmetic        => weightTypeCosmetic,
+            CardType.NewWeapon       => weightTypeNewWeapon,
+            CardType.LevelUpPowerUp  => weightTypeLevelUpPowerUp,
+            CardType.RarityUpPowerUp => weightTypeRarityUpPowerUp,
+            _                        => 0f,
         };
 
         private static bool PrerequisitesMet(UpgradeCardSO card, HashSet<string> ownedCardIds)

--- a/Assets/_CyberPickle/Code/Gameplay/Weapons/ElementVfxLibrary.cs
+++ b/Assets/_CyberPickle/Code/Gameplay/Weapons/ElementVfxLibrary.cs
@@ -1,0 +1,135 @@
+// File: Assets/_CyberPickle/Code/Gameplay/Weapons/ElementVfxLibrary.cs
+// Namespace: CyberPickle.Gameplay.Weapons
+//
+// Single global SO mapping ElementId → (flashPrefab, projectilePrefab,
+// hitPrefab). At fire time, WeaponFiring picks the trio matching the
+// weapon's currently-coupled element (driven by the power-up on the
+// same loadout axis, per M8 element coupling).
+//
+// Why centralize: 4 weapons × 8 elements = 32 visual variants. Authoring
+// 32 separate WeaponData.projectilePrefab fields per weapon is a
+// maintenance nightmare — and would break the "same projectile, different
+// scale per weapon" intent from the chat 2026-05-11 design. The library
+// holds the 8 element variants once; per-weapon scaling lives on
+// WeaponData (muzzleFlashScale / projectileScale / hitVfxScale).
+//
+// Loading: the asset MUST live under a Resources folder so the static
+// Instance property can find it at runtime without manual wiring on every
+// WeaponFiring. Convention: Assets/_CyberPickle/Resources/ElementVfxLibrary.asset.
+// Falls back to null gracefully if the asset is missing — WeaponFiring
+// treats null library as "spawn nothing" (silent — no errors).
+
+using System;
+using UnityEngine;
+using CyberPickle.Core;
+
+namespace CyberPickle.Gameplay.Weapons
+{
+    [CreateAssetMenu(menuName = "CyberPickle/Gameplay/Element VFX Library", fileName = "ElementVfxLibrary")]
+    public class ElementVfxLibrary : ScriptableObject
+    {
+        [Serializable]
+        public struct Entry
+        {
+            [Tooltip("Which element this trio covers. The library has one entry per ElementId; lookups by element find the entry with the matching id.")]
+            public ElementId element;
+
+            [Tooltip("Spawned at the weapon's muzzle on fire. One-shot — auto-destroys after its particle systems finish.")]
+            public GameObject flashPrefab;
+
+            [Tooltip("The visual projectile spawned per shot. Hovl AAA projectile prefab (with embedded particle systems).")]
+            public GameObject projectilePrefab;
+
+            [Tooltip("Spawned at the projectile's impact point on collision. Scaled by hitVfxScale × damage / crit / AoE (M9 PR F).")]
+            public GameObject hitPrefab;
+        }
+
+        [Tooltip("One entry per ElementId. Should contain 8 entries (None + 7 elements). Missing entries fall through to the first entry (typically None / neutral chrome).")]
+        public Entry[] entries = new Entry[8];
+
+        // ─── Static lookup ────────────────────────────────────────────────
+
+        private const string ResourcesPath = "ElementVfxLibrary";
+
+        private static ElementVfxLibrary _cached;
+        private static bool _lookedUp;
+
+        /// <summary>
+        /// Auto-loaded singleton. The asset lives under a Resources folder
+        /// at <c>Resources/ElementVfxLibrary.asset</c>. Returns null if the
+        /// asset is missing — callers should null-check and treat as "no
+        /// library configured" (spawn no flash / use weaponData fallback).
+        /// </summary>
+        public static ElementVfxLibrary Instance
+        {
+            get
+            {
+                if (!_lookedUp)
+                {
+                    _cached = Resources.Load<ElementVfxLibrary>(ResourcesPath);
+                    _lookedUp = true;
+                    if (_cached == null)
+                    {
+                        Debug.LogWarning(
+                            "[ElementVfxLibrary] No ElementVfxLibrary asset found at " +
+                            "Resources/ElementVfxLibrary. Per-element VFX won't spawn. " +
+                            "Create one via Assets → Create → CyberPickle → Gameplay → Element VFX Library, " +
+                            "place it under a Resources folder, and name it 'ElementVfxLibrary'.");
+                    }
+                }
+                return _cached;
+            }
+        }
+
+        /// <summary>
+        /// Editor-only: clear the cached singleton so subsequent <see cref="Instance"/>
+        /// calls re-load from Resources. Useful when authoring the asset
+        /// during play mode.
+        /// </summary>
+        public static void ClearCache()
+        {
+            _cached = null;
+            _lookedUp = false;
+        }
+
+        // ─── Lookup ────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Get the VFX trio for an element. Falls back to the first entry
+        /// (typically <see cref="ElementId.None"/>) when no match exists.
+        /// O(8) linear search — fine, the array is tiny.
+        /// </summary>
+        public Entry Get(ElementId element)
+        {
+            if (entries == null || entries.Length == 0) return default;
+            for (int i = 0; i < entries.Length; i++)
+            {
+                if (entries[i].element == element) return entries[i];
+            }
+            // Fallback to first entry (the "Neutral" slot).
+            return entries[0];
+        }
+
+        // ─── Editor validation ────────────────────────────────────────────
+
+#if UNITY_EDITOR
+        private void OnValidate()
+        {
+            // Warn on duplicate element entries — designers should have one
+            // entry per ElementId, not two Fire entries.
+            if (entries == null) return;
+            var seen = new System.Collections.Generic.HashSet<ElementId>();
+            for (int i = 0; i < entries.Length; i++)
+            {
+                if (!seen.Add(entries[i].element))
+                {
+                    Debug.LogWarning(
+                        $"[ElementVfxLibrary] Duplicate entry for element '{entries[i].element}' at index {i}. " +
+                        $"Only the first occurrence will be returned by Get().",
+                        this);
+                }
+            }
+        }
+#endif
+    }
+}

--- a/Assets/_CyberPickle/Code/Gameplay/Weapons/ElementVfxLibrary.cs.meta
+++ b/Assets/_CyberPickle/Code/Gameplay/Weapons/ElementVfxLibrary.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8a2db73577ddc2b48bbfaac73acdf385

--- a/Assets/_CyberPickle/Code/Gameplay/Weapons/LoadoutAxis.cs
+++ b/Assets/_CyberPickle/Code/Gameplay/Weapons/LoadoutAxis.cs
@@ -1,0 +1,68 @@
+// File: Assets/_CyberPickle/Code/Gameplay/Weapons/LoadoutAxis.cs
+// Namespace: CyberPickle.Gameplay.Weapons
+//
+// One axis of the player's cross-shaped loadout. An axis is a paired
+// (weapon, power-up) tuple that shares an element identity. With the
+// default 4 axes (N/E/S/W), there are 4 weapon slots + 4 power-up slots
+// = 8 cells in the cross HUD.
+//
+// Slotting rules (per chat 2026-05-11):
+//   - Either field can be null (axis can hold a power-up with no weapon,
+//     a weapon with no power-up, or both).
+//   - The axis's element comes from the slotted power-up. If a weapon
+//     is present, it inherits that element (which drives its musical mode
+//     per procedural_music_reference.md §22.4).
+//   - When the power-up is removed, the weapon's element falls back to
+//     ElementId.None (neutral) — production weapons roll neutral by
+//     default; element only ever comes from power-up coupling.
+//   - No replacement: once an axis cell is full, it stays full until the
+//     run ends. The card pool filters out cards that would land on a full
+//     cell — see UpgradePoolSO loadout-aware filter (M8 step 2).
+//
+// Class (not struct) so call sites can do `axis.weapon = X` without
+// having to fetch + reassign back into the array. The 4-class allocation
+// per run is negligible.
+
+using System;
+
+namespace CyberPickle.Gameplay.Weapons
+{
+    /// <summary>
+    /// One axis of the cross loadout. Pair of (weapon, power-up) sharing
+    /// an element identity.
+    /// </summary>
+    [Serializable]
+    public class LoadoutAxis
+    {
+        /// <summary>
+        /// Stable axis index (0..N-1). Set by <see cref="WeaponLoadoutRuntime"/>
+        /// when the axis is allocated; never mutated thereafter.
+        /// </summary>
+        public int axisIndex;
+
+        /// <summary>
+        /// Weapon slotted on this axis, or null if empty. Inherits its
+        /// element from <see cref="powerUp"/> when both are present.
+        /// </summary>
+        public WeaponInstanceData weapon;
+
+        /// <summary>
+        /// Power-up slotted on this axis, or null if empty. Its stat
+        /// bonus applies globally (registered as a StatModifier on
+        /// PlayerStats); its element confers locally to <see cref="weapon"/>.
+        /// </summary>
+        public PowerUpInstanceData powerUp;
+
+        /// <summary>True iff a weapon is slotted on this axis.</summary>
+        public bool HasWeapon => weapon != null && weapon.IsValid;
+
+        /// <summary>True iff a power-up is slotted on this axis.</summary>
+        public bool HasPowerUp => powerUp != null && powerUp.IsValid;
+
+        /// <summary>True iff both slots are empty (axis is fully unused).</summary>
+        public bool IsEmpty => !HasWeapon && !HasPowerUp;
+
+        /// <summary>True iff both slots are filled (axis can't accept more cards).</summary>
+        public bool IsFull => HasWeapon && HasPowerUp;
+    }
+}

--- a/Assets/_CyberPickle/Code/Gameplay/Weapons/LoadoutAxis.cs.meta
+++ b/Assets/_CyberPickle/Code/Gameplay/Weapons/LoadoutAxis.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4da873ddac5e4974d8dd7572c493f2ee

--- a/Assets/_CyberPickle/Code/Gameplay/Weapons/PowerUpInstanceData.cs
+++ b/Assets/_CyberPickle/Code/Gameplay/Weapons/PowerUpInstanceData.cs
@@ -1,0 +1,96 @@
+// File: Assets/_CyberPickle/Code/Gameplay/Weapons/PowerUpInstanceData.cs
+// Namespace: CyberPickle.Gameplay.Weapons
+//
+// Runtime per-axis power-up record. Mirrors the shape of WeaponInstanceData
+// for symmetry. Created when a power-up card is committed to a loadout
+// axis; destroyed when the run ends or a future replacement card lands on
+// the same axis (replacement is currently disallowed by design — see
+// CLAUDE.md M8 design notes — but the lifecycle hook exists for the day
+// the rule changes).
+//
+// Two characteristics, mirroring PowerUpData's design:
+//   - GLOBAL: stat boost (affectedStat × magnitude) — applies via a
+//     StatModifier added to PlayerStats. Sourced as
+//     "powerup_<id>_axis<N>" so removal is one bulk call.
+//   - LOCAL: element conferred to the WEAPON on the same axis. When
+//     this power-up is added/removed/changed, the axis's weapon's
+//     ElementId is updated by WeaponLoadoutRuntime.
+//
+// Why "Level" exists if the M8 model only scales magnitude by Rarity:
+// per the user's design (chat 2026-05-11), upgrade cards are dual-axis
+// (Level + Rarity) for power-ups too. Level scaling reserved for M8
+// step 2 — currently unused but stored so step 2 can wire it without
+// migrating runtime data.
+
+using System;
+using CyberPickle.Core;
+using CyberPickle.Shop.Equipment.Data;
+
+namespace CyberPickle.Gameplay.Weapons
+{
+    /// <summary>
+    /// Per-equipped-power-up runtime record.
+    /// </summary>
+    [Serializable]
+    public class PowerUpInstanceData
+    {
+        /// <summary>
+        /// Direct reference to the <see cref="PowerUpData"/> asset that
+        /// defines this power-up's stat target + per-rarity magnitude curve.
+        /// </summary>
+        public PowerUpData powerUpData;
+
+        /// <summary>
+        /// Stable string id (mirrors <c>powerUpData.equipmentId</c>) for
+        /// analytics + tracker attribution.
+        /// </summary>
+        public string PowerUpId => powerUpData != null ? powerUpData.equipmentId : string.Empty;
+
+        /// <summary>
+        /// Level axis: 1..5. Reserved for M8 step 2 (level upgrade cards
+        /// for power-ups). Currently unused by the magnitude formula but
+        /// stored for forward compat.
+        /// </summary>
+        public int level = 1;
+
+        /// <summary>
+        /// Rarity axis: drives the magnitude lookup in
+        /// <c>PowerUpData.GetMagnitudeForRarity</c>. Rolled at draft time
+        /// (Luck-modulated via <c>RarityRollService</c>); upgradeable
+        /// in-run via Rarity-up cards.
+        /// </summary>
+        public Rarity rarity = Rarity.Common;
+
+        /// <summary>
+        /// Element this power-up confers to its axis's weapon (if any).
+        /// Rolled at draft time — same template asset can show up as
+        /// Fire / Lightning / Ice / etc. variants.
+        /// </summary>
+        public ElementId element = ElementId.None;
+
+        /// <summary>
+        /// Axis this power-up occupies in the player's loadout. Mirrors
+        /// the slotIndex on <see cref="WeaponInstanceData"/> for symmetry.
+        /// </summary>
+        public int axisIndex;
+
+        /// <summary>True iff this instance has a valid <see cref="powerUpData"/> reference.</summary>
+        public bool IsValid => powerUpData != null;
+
+        /// <summary>
+        /// Current magnitude (decimal fraction, 0.10 = +10%) given this
+        /// instance's rarity. Used by <c>WeaponLoadoutRuntime</c> when
+        /// applying / refreshing the StatModifier on PlayerStats.
+        /// </summary>
+        public float CurrentMagnitude
+            => powerUpData != null ? powerUpData.GetMagnitudeForRarity(rarity) : 0f;
+
+        /// <summary>
+        /// SourceId used when adding the StatModifier to PlayerStats.
+        /// Includes the axis index so two power-ups of the same template
+        /// on different axes don't collide.
+        /// </summary>
+        public string ModifierSourceId
+            => $"powerup_{PowerUpId}_axis{axisIndex}";
+    }
+}

--- a/Assets/_CyberPickle/Code/Gameplay/Weapons/PowerUpInstanceData.cs.meta
+++ b/Assets/_CyberPickle/Code/Gameplay/Weapons/PowerUpInstanceData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8d820de6d5946d544a31f4cdcce6b2b4

--- a/Assets/_CyberPickle/Code/Gameplay/Weapons/WeaponFiring.cs
+++ b/Assets/_CyberPickle/Code/Gameplay/Weapons/WeaponFiring.cs
@@ -324,6 +324,12 @@ namespace CyberPickle.Gameplay.Weapons
                 Debug.Log($"<color=cyan>[WeaponFiring]</color> Slot {slotIndex} '{idForSource}' fired — L{lvl} {rar} dmg={effectiveDamage:F1} spd={effectiveSpeed:F1}.");
             }
 
+            // Spawn the muzzle flash (Mono-side, one-shot). The visual is
+            // looked up from ElementVfxLibrary by the weapon's currently-
+            // coupled element; scale comes from weaponData.muzzleFlashScale.
+            // M9 PR A — projectile + hit VFX library swap lands in later PRs.
+            SpawnMuzzleFlash(instance);
+
             // Broadcast to the audio bus. Stage 0: a Debug.Log entry per shot
             // (only when VerboseLogging is on — off by default to avoid log
             // flood). Stage 2 (M9 Wwise): this becomes the per-shot Ak event
@@ -332,6 +338,52 @@ namespace CyberPickle.Gameplay.Weapons
             // so the conductor can pick the right pitch/sample; for the stub
             // we just signal that A shot happened.
             MusicEventBus.Fire(MusicEvent.WeaponFire, gameObject.name);
+        }
+
+        // ─── Muzzle flash (M9 PR A) ───────────────────────────────────────
+
+        /// <summary>
+        /// Spawn the muzzle-flash GameObject for this shot. Visual picked
+        /// from <see cref="ElementVfxLibrary"/> by the weapon's currently-
+        /// coupled <see cref="ElementId"/>. Scaled by
+        /// <c>weaponData.muzzleFlashScale</c>.
+        ///
+        /// One-shot — auto-destroys after the longest particle system's
+        /// duration so we don't leak GameObjects. Spawned UNPARENTED (so it
+        /// stays where it was fired even as the weapon rotates to track the
+        /// next target).
+        ///
+        /// Silent no-op when:
+        ///   - The library asset is missing (warned once via the library)
+        ///   - The element has no flashPrefab authored
+        ///   - The flash scale is zero (designer explicitly disabled it)
+        /// </summary>
+        private void SpawnMuzzleFlash(WeaponInstanceData instance)
+        {
+            var lib = ElementVfxLibrary.Instance;
+            if (lib == null) return;
+
+            ElementId element = instance != null && instance.IsValid ? instance.element : ElementId.None;
+            var entry = lib.Get(element);
+            if (entry.flashPrefab == null) return;
+
+            float scale = weaponData != null ? weaponData.muzzleFlashScale : 1f;
+            if (scale <= 0f) return;
+
+            // Spawn at muzzle, oriented along muzzle.forward.
+            GameObject flash = UnityEngine.Object.Instantiate(entry.flashPrefab, muzzle.position, muzzle.rotation);
+            flash.transform.localScale = Vector3.one * scale;
+
+            // Auto-cleanup. Use the longest particle system duration + a
+            // small grace period so trailing particles finish before destroy.
+            float maxDuration = 1.0f;
+            foreach (var ps in flash.GetComponentsInChildren<ParticleSystem>())
+            {
+                var main = ps.main;
+                float dur = main.duration + main.startLifetime.constantMax;
+                if (dur > maxDuration) maxDuration = dur;
+            }
+            UnityEngine.Object.Destroy(flash, maxDuration + 0.5f);
         }
 
         /// <summary>

--- a/Assets/_CyberPickle/Code/Gameplay/Weapons/WeaponInstanceData.cs
+++ b/Assets/_CyberPickle/Code/Gameplay/Weapons/WeaponInstanceData.cs
@@ -95,11 +95,17 @@ namespace CyberPickle.Gameplay.Weapons
         /// <summary>
         /// Active element. Drives the musical mode for this weapon's
         /// pattern playback (Fire = Phrygian Dominant, etc. — see
-        /// <c>procedural_music_reference.md</c> §8). Initialized from
-        /// <c>weaponData.defaultElement</c> when the weapon enters the
-        /// loadout. Locked to a new value when an element-coupled
-        /// power-up triggers the weapon's evolution (M9 work — see
-        /// <c>procedural_music_reference.md</c> §22.4).
+        /// <c>procedural_music_reference.md</c> §8).
+        ///
+        /// 2026-05-11 (M8): element is now SOURCED FROM THE AXIS'S POWER-UP
+        /// (not from <c>weaponData.defaultElement</c>). When a weapon enters
+        /// the loadout, it inherits the element of the power-up already on
+        /// the same axis (or <see cref="ElementId.None"/> if no power-up).
+        /// When a power-up is added/removed/replaced, the axis's weapon's
+        /// element is updated by <c>WeaponLoadoutRuntime</c> and
+        /// <c>MusicEvent.WeaponElementChanged</c> fires.
+        /// <c>WeaponData.defaultElement</c> remains for editor-test-only
+        /// scenarios — production weapons start neutral.
         /// </summary>
         public ElementId element = ElementId.None;
 

--- a/Assets/_CyberPickle/Code/Gameplay/Weapons/WeaponLoadoutRuntime.cs
+++ b/Assets/_CyberPickle/Code/Gameplay/Weapons/WeaponLoadoutRuntime.cs
@@ -1,44 +1,51 @@
 // File: Assets/_CyberPickle/Code/Gameplay/Weapons/WeaponLoadoutRuntime.cs
 // Namespace: CyberPickle.Gameplay.Weapons
 //
-// Scene-bound Manager<T> that owns the player's per-run weapon loadout.
-// Holds up to 4 WeaponInstanceData records (1 starting weapon + up to 3
-// drafted in-run, per economy_design_v1.md §7).
+// Scene-bound Manager<T> that owns the player's per-run loadout. The
+// loadout is a fixed-size array of LoadoutAxis records — each axis pairs
+// one weapon slot + one power-up slot, sharing an element identity.
+//
+// Default config: 4 axes (N / E / S / W). Configurable up to 8 (adds
+// diagonals NE / SE / SW / NW). The axis count is decided once at run
+// start and stays fixed for the duration of the run.
 //
 // Source of truth for:
-//   - Which weapons are equipped right now (slot 0..3)
-//   - Each equipped weapon's Level (1..5 + Evolved) and Rarity (Common..Legendary)
+//   - Which weapons + power-ups are equipped right now (per axis)
+//   - Each weapon's Level (1..5 + Evolved) and Rarity (Common..Legendary)
+//   - Each power-up's Rarity (Common..Legendary) and rolled Element
+//   - Element coupling: an axis's weapon inherits the element of the
+//     power-up on the SAME axis (or ElementId.None if no power-up)
+//   - Power-up stat boosts wired into PlayerStats as StatModifiers,
+//     keyed on "powerup_<id>_axis<N>" sourceIds (clean removal)
 //
 // NOT the source of truth for:
-//   - WeaponData design (that's the ScriptableObject — each instance carries
-//     a weaponId pointing back to it)
-//   - Damage numbers (those flow through PlayerStats × WeaponData × Rarity
-//     at projectile spawn time; see WeaponFiring + ProjectileCollisionSystem)
+//   - WeaponData / PowerUpData design (those are SOs)
+//   - Damage numbers (those flow through PlayerStats × WeaponData × Rarity)
+//   - PlayerStats themselves — we only feed it modifiers; it owns the cache
 //
 // Lifecycle:
 //   - Scene-bound (PersistAcrossScenes => false). Created when the Game
 //     scene loads, destroyed when it unloads.
-//   - Subscribes to MusicEventBus.OnEvent at OnManagerEnabled. On
-//     MusicEvent.RunStart, clears the loadout (fresh runs start empty —
-//     pre-run starting-weapon population is the responsibility of the
-//     run bootstrap, e.g., GameSceneBootstrap, calling TryAddWeapon
-//     after RunStart fires).
+//   - Subscribes to MusicEventBus.OnEvent (process-global static, no
+//     spawn-timing concerns). Currently nothing acted-on; the RunStart
+//     auto-clear was removed in M7.4 (see HandleMusicEvent comment below).
 //
-// Event semantics (subscribers can wire either C# events or MusicEventBus):
-//   - C# events for tight in-process consumers (HUD, music conductor).
-//     Provide slot-level granularity.
-//   - MusicEventBus events for cross-cutting consumers (analytics, future
-//     Wwise integration). Same slot index passed as the payload.
+// Event semantics:
+//   - C# events fire on every state change. Argument is the axis index.
+//   - MusicEventBus events fire alongside for cross-cutting consumers
+//     (analytics, future Wwise integration).
+//   - Element coupling: when a power-up is added/removed, the axis's
+//     weapon's element is updated and MusicEvent.WeaponElementChanged
+//     fires for the same axis index.
 //
-// Threading: main-thread only. All mutation methods call into _slots List
-// (not thread-safe). Burst-side weapon entities mirror state via the
-// WeaponLevel / WeaponRarity ECS components — sync points are TBD until
-// Phase 4 wiring lands.
+// Threading: main-thread only. Never call mutation methods from Burst.
 //
 // Cross-references:
-//   - WeaponInstanceData (the data shape being managed)
-//   - RarityRollService (rolls initial rarity on weapon add)
-//   - economy_design_v1.md §7 (slot count rationale)
+//   - LoadoutAxis (per-axis pair record)
+//   - WeaponInstanceData / PowerUpInstanceData (the inner shapes)
+//   - RarityRollService (rolls initial rarity on add)
+//   - PlayerStats (stat-modifier sink for power-up bonuses)
+//   - economy_design_v1.md §7 (slot-count rationale)
 //   - weapon_rarity_v1.md §7 (RTPC binding spec)
 
 using System;
@@ -48,6 +55,7 @@ using CyberPickle.Core;
 using CyberPickle.Core.Management;
 using CyberPickle.Core.Services;
 using CyberPickle.Gameplay.Audio;
+using CyberPickle.Gameplay.Stats;
 using CyberPickle.Shop.Equipment.Data;
 
 namespace CyberPickle.Gameplay.Weapons
@@ -56,140 +64,308 @@ namespace CyberPickle.Gameplay.Weapons
     public class WeaponLoadoutRuntime : Manager<WeaponLoadoutRuntime>
     {
         /// <summary>
-        /// Hard cap on equipped weapons in a single run: 1 starting + 3 drafted = 4.
-        /// Per economy_design_v1.md §7 — kept small so every weapon matters.
+        /// Default number of axes (N / E / S / W). Configurable per-run via
+        /// <see cref="SetAxisCount"/> for an 8-axis variant (diagonals).
         /// </summary>
-        public const int MaxSlots = 4;
+        public const int DefaultAxisCount = 4;
+
+        /// <summary>Hard upper bound on axes — UI layouts assume ≤ 8.</summary>
+        public const int MaxAxisCount = 8;
+
+        /// <summary>
+        /// Back-compat alias for the legacy <c>MaxSlots</c> constant. Some
+        /// HUD code still references this — kept as DefaultAxisCount so
+        /// existing inspector-array sizes match.
+        /// </summary>
+        public const int MaxSlots = DefaultAxisCount;
 
         [Header("Diagnostics")]
         [Tooltip("Log loadout changes to the console.")]
         public bool verbose = false;
 
-        // Scene-bound — see RunStateManager / PerWeaponStatsTracker for the
-        // same pattern. Loadout is run-scoped; persisting across scenes
-        // would carry stale data into the next run.
+        // Scene-bound. Loadout is run-scoped; persisting would carry stale
+        // data into the next run.
         protected override bool PersistAcrossScenes => false;
 
         // ─── State ────────────────────────────────────────────────────────
 
-        private readonly List<WeaponInstanceData> _slots = new List<WeaponInstanceData>(MaxSlots);
+        private LoadoutAxis[] _axes;
+        private int _axisCount = DefaultAxisCount;
 
-        /// <summary>Read-only view of equipped weapons. Order = slotIndex.</summary>
-        public IReadOnlyList<WeaponInstanceData> Slots => _slots;
+        /// <summary>Read-only view of all axes (always full length, may contain empty axes).</summary>
+        public IReadOnlyList<LoadoutAxis> Axes
+        {
+            get { EnsureInitialized(); return _axes; }
+        }
 
-        /// <summary>Number of currently equipped weapons (0..MaxSlots).</summary>
-        public int Count => _slots.Count;
+        /// <summary>Number of axes (4 default, configurable up to 8).</summary>
+        public int AxisCount => _axisCount;
 
-        /// <summary>True when no more weapons can be added.</summary>
-        public bool IsFull => _slots.Count >= MaxSlots;
+        /// <summary>Number of weapons currently equipped across all axes.</summary>
+        public int WeaponCount
+        {
+            get
+            {
+                EnsureInitialized();
+                int n = 0;
+                for (int i = 0; i < _axisCount; i++) if (_axes[i].HasWeapon) n++;
+                return n;
+            }
+        }
+
+        /// <summary>Number of power-ups currently equipped across all axes.</summary>
+        public int PowerUpCount
+        {
+            get
+            {
+                EnsureInitialized();
+                int n = 0;
+                for (int i = 0; i < _axisCount; i++) if (_axes[i].HasPowerUp) n++;
+                return n;
+            }
+        }
+
+        /// <summary>True when every axis already has a weapon (no more new-weapon cards).</summary>
+        public bool AreWeaponSlotsFull => WeaponCount >= _axisCount;
+
+        /// <summary>True when every axis already has a power-up (no more new-power-up cards).</summary>
+        public bool ArePowerUpSlotsFull => PowerUpCount >= _axisCount;
+
+        /// <summary>Back-compat alias for legacy callers — true when weapon slots are full.</summary>
+        public bool IsFull => AreWeaponSlotsFull;
+
+        /// <summary>Back-compat alias for legacy callers — number of weapons equipped.</summary>
+        public int Count => WeaponCount;
+
+        /// <summary>
+        /// Read-only view of equipped weapons (drops empty axes). Order
+        /// matches axis index. Used by HUD components that iterate weapons
+        /// in display order. Allocates on each call — fine for HUD refresh
+        /// rates, avoid in hot per-frame paths.
+        /// </summary>
+        public IReadOnlyList<WeaponInstanceData> Slots
+        {
+            get
+            {
+                EnsureInitialized();
+                var list = new List<WeaponInstanceData>(_axisCount);
+                for (int i = 0; i < _axisCount; i++)
+                    if (_axes[i].HasWeapon) list.Add(_axes[i].weapon);
+                return list;
+            }
+        }
 
         // ─── Events (C#-side, granular) ───────────────────────────────────
 
-        /// <summary>Fires after a new weapon enters the loadout. Argument is the new instance.</summary>
+        /// <summary>Fires after a new weapon enters an axis. Argument is the new instance.</summary>
         public event Action<WeaponInstanceData> OnWeaponAdded;
 
-        /// <summary>Fires after a weapon's Level changes. Argument is the slot index.</summary>
+        /// <summary>Fires after a weapon's Level changes. Argument is the axis index.</summary>
         public event Action<int> OnWeaponLevelChanged;
 
-        /// <summary>Fires after a weapon's Rarity changes. Argument is the slot index.</summary>
+        /// <summary>Fires after a weapon's Rarity changes. Argument is the axis index.</summary>
         public event Action<int> OnWeaponRarityChanged;
 
-        /// <summary>Fires when a weapon transitions to its evolved form. Argument is the slot index.</summary>
+        /// <summary>Fires when a weapon transitions to its evolved form. Argument is the axis index.</summary>
         public event Action<int> OnWeaponEvolved;
 
-        /// <summary>Fires after the loadout is cleared (e.g., on RunStart).</summary>
+        /// <summary>Fires when a weapon's Element changes (typically from power-up coupling). Argument is the axis index.</summary>
+        public event Action<int> OnWeaponElementChanged;
+
+        /// <summary>Fires after a new power-up enters an axis. Argument is the new instance.</summary>
+        public event Action<PowerUpInstanceData> OnPowerUpAdded;
+
+        /// <summary>Fires after a power-up is removed from an axis. Argument is the axis index.</summary>
+        public event Action<int> OnPowerUpRemoved;
+
+        /// <summary>Fires after a power-up's Level changes. Argument is the axis index.</summary>
+        public event Action<int> OnPowerUpLevelChanged;
+
+        /// <summary>Fires after a power-up's Rarity changes. Argument is the axis index.</summary>
+        public event Action<int> OnPowerUpRarityChanged;
+
+        /// <summary>Fires after the entire loadout is cleared (e.g., on scene unload).</summary>
         public event Action OnLoadoutCleared;
 
-        // ─── Public API ───────────────────────────────────────────────────
+        // ─── Cached references ────────────────────────────────────────────
 
-        /// <summary>
-        /// Returns the WeaponInstanceData at the given slot, or null if the
-        /// slot is empty / out of range.
-        /// </summary>
-        public WeaponInstanceData GetSlot(int slotIndex)
+        // PlayerStats lives in the scene as a sibling of the Player root.
+        // Cached lazily on first access — avoids ordering issues with
+        // OnManagerEnabled vs player spawn.
+        private PlayerStats _cachedPlayerStats;
+
+        private PlayerStats GetPlayerStats()
         {
-            if (slotIndex < 0 || slotIndex >= _slots.Count) return null;
-            return _slots[slotIndex];
+            if (_cachedPlayerStats != null) return _cachedPlayerStats;
+            _cachedPlayerStats = UnityEngine.Object.FindFirstObjectByType<PlayerStats>();
+            return _cachedPlayerStats;
+        }
+
+        // ─── Public API: axis access ─────────────────────────────────────
+
+        /// <summary>Returns the axis at the given index, or null if out of range.</summary>
+        public LoadoutAxis GetAxis(int axisIndex)
+        {
+            EnsureInitialized();
+            if (axisIndex < 0 || axisIndex >= _axisCount) return null;
+            return _axes[axisIndex];
         }
 
         /// <summary>
-        /// First slot whose weaponData has the given equipmentId, or null
-        /// if not equipped. O(MaxSlots) — fine, list is tiny.
+        /// Returns the WEAPON at the given axis, or null if the axis is out
+        /// of range or has no weapon. Back-compat with legacy <c>GetSlot</c>
+        /// callers (WeaponFiring, WeaponSlotsPanel, etc.).
         /// </summary>
+        public WeaponInstanceData GetSlot(int axisIndex)
+        {
+            var axis = GetAxis(axisIndex);
+            return axis != null ? axis.weapon : null;
+        }
+
+        /// <summary>Returns the POWER-UP at the given axis, or null if empty/out-of-range.</summary>
+        public PowerUpInstanceData GetPowerUp(int axisIndex)
+        {
+            var axis = GetAxis(axisIndex);
+            return axis != null ? axis.powerUp : null;
+        }
+
+        /// <summary>First axis whose weapon matches the given equipmentId, or null.</summary>
         public WeaponInstanceData FindByWeaponId(string weaponId)
         {
             if (string.IsNullOrEmpty(weaponId)) return null;
-            for (int i = 0; i < _slots.Count; i++)
+            EnsureInitialized();
+            for (int i = 0; i < _axisCount; i++)
             {
-                if (_slots[i].WeaponId == weaponId) return _slots[i];
+                var w = _axes[i].weapon;
+                if (w != null && w.IsValid && w.WeaponId == weaponId) return w;
             }
             return null;
         }
 
-        /// <summary>
-        /// First slot referencing the given <see cref="WeaponData"/>, or
-        /// null if not equipped. Convenience for SO-driven callers.
-        /// </summary>
+        /// <summary>First axis whose weapon matches the given <see cref="WeaponData"/>, or null.</summary>
         public WeaponInstanceData FindByWeaponData(WeaponData weapon)
         {
             if (weapon == null) return null;
-            for (int i = 0; i < _slots.Count; i++)
+            EnsureInitialized();
+            for (int i = 0; i < _axisCount; i++)
             {
-                if (_slots[i].weaponData == weapon) return _slots[i];
+                var w = _axes[i].weapon;
+                if (w != null && w.weaponData == weapon) return w;
             }
             return null;
         }
 
+        /// <summary>First axis whose power-up matches the given <see cref="PowerUpData"/>, or null.</summary>
+        public PowerUpInstanceData FindByPowerUpData(PowerUpData powerUp)
+        {
+            if (powerUp == null) return null;
+            EnsureInitialized();
+            for (int i = 0; i < _axisCount; i++)
+            {
+                var p = _axes[i].powerUp;
+                if (p != null && p.powerUpData == powerUp) return p;
+            }
+            return null;
+        }
+
+        /// <summary>Index of the first axis whose weapon slot is empty, or -1 if all full.</summary>
+        public int FirstEmptyWeaponAxis()
+        {
+            EnsureInitialized();
+            for (int i = 0; i < _axisCount; i++)
+                if (!_axes[i].HasWeapon) return i;
+            return -1;
+        }
+
+        /// <summary>Index of the first axis whose power-up slot is empty, or -1 if all full.</summary>
+        public int FirstEmptyPowerUpAxis()
+        {
+            EnsureInitialized();
+            for (int i = 0; i < _axisCount; i++)
+                if (!_axes[i].HasPowerUp) return i;
+            return -1;
+        }
+
+        // ─── Public API: weapon mutation ─────────────────────────────────
+
         /// <summary>
-        /// Add a weapon at the given initial Rarity. Used when:
-        ///   - The starting weapon enters the loadout at RunStart (rarity
-        ///     typically Common, or character-specific).
-        ///   - An in-run weapon draft locks in a specific roll (caller
-        ///     already rolled the rarity via RarityRollService).
-        ///   - A boss-drop or fixed-rarity scripted reward is applied.
+        /// Add a weapon to the FIRST EMPTY weapon axis. Convenience for
+        /// "give me whatever axis you've got" callers (PlayerLoadoutLoader,
+        /// generic add-this-card flow). For explicit-axis-pick UI flows,
+        /// use <see cref="TryAddWeaponAt"/>.
         ///
-        /// Returns false if the loadout is full or <paramref name="weapon"/>
+        /// Returns false if all weapon slots are full or <paramref name="weapon"/>
         /// is null. On success, fires OnWeaponAdded + MusicEvent.WeaponAdded.
-        /// The instance's element is initialized from <c>weapon.defaultElement</c>
-        /// (per procedural_music_reference.md §22.4).
         /// </summary>
         public bool TryAddWeapon(WeaponData weapon, Rarity initialRarity, out WeaponInstanceData added)
         {
-            added = null;
-            if (IsFull)
+            int axis = FirstEmptyWeaponAxis();
+            if (axis < 0)
             {
-                if (verbose) Debug.LogWarning($"[WeaponLoadoutRuntime] TryAddWeapon ignored — loadout full ({MaxSlots}/{MaxSlots}).");
+                added = null;
+                if (verbose) Debug.LogWarning($"[WeaponLoadoutRuntime] TryAddWeapon ignored — all {_axisCount} weapon slots full.");
+                return false;
+            }
+            return TryAddWeaponAt(axis, weapon, initialRarity, out added);
+        }
+
+        /// <summary>
+        /// Add a weapon to a specific axis. Used by the cross-UI slot-picker
+        /// flow where the player chose which axis to fill.
+        ///
+        /// Returns false if the axis is out of range, already has a weapon,
+        /// or <paramref name="weapon"/> is null. On success, fires
+        /// OnWeaponAdded + MusicEvent.WeaponAdded. The new weapon's element
+        /// inherits from any power-up already on this axis (or
+        /// ElementId.None if the axis has no power-up).
+        /// </summary>
+        public bool TryAddWeaponAt(int axisIndex, WeaponData weapon, Rarity initialRarity, out WeaponInstanceData added)
+        {
+            added = null;
+            EnsureInitialized();
+            if (axisIndex < 0 || axisIndex >= _axisCount)
+            {
+                if (verbose) Debug.LogWarning($"[WeaponLoadoutRuntime] TryAddWeaponAt({axisIndex}) — out of range (0..{_axisCount - 1}).");
                 return false;
             }
             if (weapon == null)
             {
-                if (verbose) Debug.LogWarning("[WeaponLoadoutRuntime] TryAddWeapon ignored — weaponData is null.");
+                if (verbose) Debug.LogWarning("[WeaponLoadoutRuntime] TryAddWeaponAt — weaponData is null.");
+                return false;
+            }
+            var axis = _axes[axisIndex];
+            if (axis.HasWeapon)
+            {
+                if (verbose) Debug.LogWarning($"[WeaponLoadoutRuntime] TryAddWeaponAt({axisIndex}) — axis already has weapon '{axis.weapon.WeaponId}'.");
                 return false;
             }
 
-            int newSlot = _slots.Count;
+            // Element comes from the axis's power-up (if any). Production
+            // weapons roll Neutral by default — defaultElement on WeaponData
+            // is test-only per chat 2026-05-11.
+            var initialElement = axis.HasPowerUp ? axis.powerUp.element : ElementId.None;
+
             added = new WeaponInstanceData
             {
                 weaponData = weapon,
                 level      = 1,
                 evolved    = false,
                 rarity     = initialRarity,
-                element    = weapon.defaultElement,
-                slotIndex  = newSlot,
+                element    = initialElement,
+                slotIndex  = axisIndex,
             };
-            _slots.Add(added);
+            axis.weapon = added;
 
-            if (verbose) Debug.Log($"<color=cyan>[WeaponLoadoutRuntime]</color> Added '{added.WeaponId}' to slot {newSlot} at rarity {initialRarity}, element {added.element}.");
+            if (verbose) Debug.Log($"<color=cyan>[WeaponLoadoutRuntime]</color> Added '{added.WeaponId}' to axis {axisIndex} at {initialRarity}, element {initialElement}.");
 
             OnWeaponAdded?.Invoke(added);
-            MusicEventBus.Fire(MusicEvent.WeaponAdded, newSlot);
+            MusicEventBus.Fire(MusicEvent.WeaponAdded, axisIndex);
             return true;
         }
 
         /// <summary>
-        /// Convenience: add a weapon with a Luck-modulated first-roll
-        /// (per RarityRollService). Used for in-run drafts where the
-        /// caller wants the standard roll rather than a fixed rarity.
+        /// Convenience: add a weapon at the first empty axis with a
+        /// Luck-modulated first-roll (per RarityRollService).
         /// </summary>
         public bool TryAddWeaponWithRoll(WeaponData weapon, float luck, out WeaponInstanceData added)
         {
@@ -198,63 +374,53 @@ namespace CyberPickle.Gameplay.Weapons
         }
 
         /// <summary>
-        /// Bump a weapon's Level by 1 (capped at 5). Returns false if the
-        /// slot is empty, out of range, or already at L5 unevolved (use
-        /// <see cref="EvolveWeapon"/> for the L5 → Evolved transition).
-        ///
-        /// Fires OnWeaponLevelChanged + MusicEvent.WeaponLevelChanged.
+        /// Bump a weapon's Level by 1 (capped at 5). Pass the AXIS index.
+        /// Returns false if the axis has no weapon, or the weapon is at L5
+        /// (use <see cref="EvolveWeapon"/> for L5 → Evolved).
         /// </summary>
-        public bool LevelUpWeapon(int slotIndex)
+        public bool LevelUpWeapon(int axisIndex)
         {
-            var w = GetSlot(slotIndex);
+            var w = GetSlot(axisIndex);
             if (w == null) return false;
             if (w.level >= 5) return false;
 
             w.level++;
-            if (verbose) Debug.Log($"<color=cyan>[WeaponLoadoutRuntime]</color> Slot {slotIndex} '{w.WeaponId}' L{w.level - 1} → L{w.level}.");
+            if (verbose) Debug.Log($"<color=cyan>[WeaponLoadoutRuntime]</color> Axis {axisIndex} weapon '{w.WeaponId}' L{w.level - 1} → L{w.level}.");
 
-            OnWeaponLevelChanged?.Invoke(slotIndex);
-            MusicEventBus.Fire(MusicEvent.WeaponLevelChanged, slotIndex);
+            OnWeaponLevelChanged?.Invoke(axisIndex);
+            MusicEventBus.Fire(MusicEvent.WeaponLevelChanged, axisIndex);
             return true;
         }
 
         /// <summary>
-        /// Bump a weapon's Rarity by N tiers (default 1, clamped at Legendary).
-        /// Returns false if the slot is empty / out of range, or true if a
-        /// change actually happened (already-Legendary returns true with no
-        /// state change but no event — caller can re-check rarity to detect).
-        ///
-        /// Fires OnWeaponRarityChanged + MusicEvent.WeaponRarityChanged on
-        /// successful change. Used by Rarity-up cards, Augment Console,
-        /// Resonator pickups, Echo Compiler keystone.
+        /// Bump a weapon's Rarity by N tiers (clamped at Legendary).
+        /// Returns false if the axis has no weapon. Already-Legendary
+        /// returns true with no event (no-op success).
         /// </summary>
-        public bool UpgradeRarity(int slotIndex, int tiers = 1)
+        public bool UpgradeRarity(int axisIndex, int tiers = 1)
         {
-            var w = GetSlot(slotIndex);
+            var w = GetSlot(axisIndex);
             if (w == null) return false;
 
             var oldRarity = w.rarity;
             var newRarity = RarityRollService.UpgradeBy(oldRarity, tiers);
-            if (newRarity == oldRarity) return true; // already at cap; no-op success
+            if (newRarity == oldRarity) return true;
 
             w.rarity = newRarity;
-            if (verbose) Debug.Log($"<color=cyan>[WeaponLoadoutRuntime]</color> Slot {slotIndex} '{w.WeaponId}' rarity {oldRarity} → {newRarity}.");
+            if (verbose) Debug.Log($"<color=cyan>[WeaponLoadoutRuntime]</color> Axis {axisIndex} weapon '{w.WeaponId}' rarity {oldRarity} → {newRarity}.");
 
-            OnWeaponRarityChanged?.Invoke(slotIndex);
-            MusicEventBus.Fire(MusicEvent.WeaponRarityChanged, slotIndex);
+            OnWeaponRarityChanged?.Invoke(axisIndex);
+            MusicEventBus.Fire(MusicEvent.WeaponRarityChanged, axisIndex);
             return true;
         }
 
         /// <summary>
-        /// Bump rarity DOWN by N tiers (clamped at Common). Used internally
-        /// by <see cref="GambleRarity"/> on failure; rarely needed elsewhere
-        /// since the design avoids visible negative numbers (CLAUDE.md
-        /// design pillar 3). Public so Black Market UI can call directly
-        /// when displaying gamble-failed flow.
+        /// Bump weapon rarity DOWN by N tiers (clamped at Common). Used by
+        /// <see cref="GambleRarity"/> on failure.
         /// </summary>
-        public bool DowngradeRarity(int slotIndex, int tiers = 1)
+        public bool DowngradeRarity(int axisIndex, int tiers = 1)
         {
-            var w = GetSlot(slotIndex);
+            var w = GetSlot(axisIndex);
             if (w == null) return false;
 
             var oldRarity = w.rarity;
@@ -262,22 +428,17 @@ namespace CyberPickle.Gameplay.Weapons
             if (newRarity == oldRarity) return true;
 
             w.rarity = newRarity;
-            if (verbose) Debug.Log($"<color=cyan>[WeaponLoadoutRuntime]</color> Slot {slotIndex} '{w.WeaponId}' rarity DOWN {oldRarity} → {newRarity}.");
+            if (verbose) Debug.Log($"<color=cyan>[WeaponLoadoutRuntime]</color> Axis {axisIndex} weapon '{w.WeaponId}' rarity DOWN {oldRarity} → {newRarity}.");
 
-            OnWeaponRarityChanged?.Invoke(slotIndex);
-            MusicEventBus.Fire(MusicEvent.WeaponRarityChanged, slotIndex);
+            OnWeaponRarityChanged?.Invoke(axisIndex);
+            MusicEventBus.Fire(MusicEvent.WeaponRarityChanged, axisIndex);
             return true;
         }
 
-        /// <summary>
-        /// Black Market gamble on a slot's rarity. Convenience wrapper
-        /// around <see cref="RarityRollService.AttemptGamble"/> that
-        /// applies the result to the loadout in one call.
-        /// </summary>
-        /// <returns>The rarity AFTER the gamble (so the UI can flash up/down).</returns>
-        public Rarity GambleRarity(int slotIndex, float successChance = 0.6f, bool hasInsurance = false)
+        /// <summary>Black Market gamble on a weapon's rarity.</summary>
+        public Rarity GambleRarity(int axisIndex, float successChance = 0.6f, bool hasInsurance = false)
         {
-            var w = GetSlot(slotIndex);
+            var w = GetSlot(axisIndex);
             if (w == null) return Rarity.Common;
 
             var oldRarity = w.rarity;
@@ -285,62 +446,284 @@ namespace CyberPickle.Gameplay.Weapons
             if (newRarity == oldRarity) return newRarity;
 
             w.rarity = newRarity;
-            if (verbose) Debug.Log($"<color=cyan>[WeaponLoadoutRuntime]</color> Slot {slotIndex} '{w.WeaponId}' GAMBLE {oldRarity} → {newRarity} (success={(newRarity > oldRarity)}, insurance={hasInsurance}).");
+            if (verbose) Debug.Log($"<color=cyan>[WeaponLoadoutRuntime]</color> Axis {axisIndex} weapon GAMBLE {oldRarity} → {newRarity}.");
 
-            OnWeaponRarityChanged?.Invoke(slotIndex);
-            MusicEventBus.Fire(MusicEvent.WeaponRarityChanged, slotIndex);
+            OnWeaponRarityChanged?.Invoke(axisIndex);
+            MusicEventBus.Fire(MusicEvent.WeaponRarityChanged, axisIndex);
             return newRarity;
         }
 
         /// <summary>
-        /// Transition a weapon to its evolved form. Requires the weapon to
-        /// be at L5 — earlier evolutions are not permitted by design (they
-        /// would skip the pattern-complexity progression).
-        ///
-        /// Returns false if the slot is empty, the weapon isn't at L5, or
-        /// it's already evolved. Fires OnWeaponEvolved + MusicEvent.WeaponEvolved.
-        ///
-        /// Note: trigger conditions (e.g., paired power-up acquired) are
-        /// checked OUTSIDE this method by the caller. This method only
-        /// applies the transition; it doesn't gate on prerequisites.
+        /// Transition a weapon to its evolved form. Requires L5; earlier
+        /// evolutions are not permitted by design.
         /// </summary>
-        public bool EvolveWeapon(int slotIndex)
+        public bool EvolveWeapon(int axisIndex)
         {
-            var w = GetSlot(slotIndex);
+            var w = GetSlot(axisIndex);
             if (w == null) return false;
             if (w.level < 5) return false;
             if (w.evolved) return false;
 
             w.evolved = true;
-            if (verbose) Debug.Log($"<color=cyan>[WeaponLoadoutRuntime]</color> Slot {slotIndex} '{w.WeaponId}' EVOLVED.");
+            if (verbose) Debug.Log($"<color=cyan>[WeaponLoadoutRuntime]</color> Axis {axisIndex} weapon '{w.WeaponId}' EVOLVED.");
 
-            OnWeaponEvolved?.Invoke(slotIndex);
-            MusicEventBus.Fire(MusicEvent.WeaponEvolved, slotIndex);
+            OnWeaponEvolved?.Invoke(axisIndex);
+            MusicEventBus.Fire(MusicEvent.WeaponEvolved, axisIndex);
+            return true;
+        }
+
+        // ─── Public API: power-up mutation ───────────────────────────────
+
+        /// <summary>
+        /// Add a power-up to the FIRST EMPTY power-up axis. Convenience
+        /// helper. For axis-explicit flows use <see cref="TryAddPowerUpAt"/>.
+        /// </summary>
+        public bool TryAddPowerUp(PowerUpData powerUp, ElementId rolledElement, Rarity initialRarity, out PowerUpInstanceData added)
+        {
+            int axis = FirstEmptyPowerUpAxis();
+            if (axis < 0)
+            {
+                added = null;
+                if (verbose) Debug.LogWarning($"[WeaponLoadoutRuntime] TryAddPowerUp ignored — all {_axisCount} power-up slots full.");
+                return false;
+            }
+            return TryAddPowerUpAt(axis, powerUp, rolledElement, initialRarity, out added);
+        }
+
+        /// <summary>
+        /// Add a power-up to a specific axis. The power-up's stat bonus is
+        /// applied GLOBALLY to PlayerStats; its element couples LOCALLY to
+        /// the axis's weapon (if any), which fires WeaponElementChanged.
+        ///
+        /// Returns false if the axis is out of range, already has a power-up,
+        /// or <paramref name="powerUp"/> is null.
+        /// </summary>
+        public bool TryAddPowerUpAt(int axisIndex, PowerUpData powerUp, ElementId rolledElement, Rarity initialRarity, out PowerUpInstanceData added)
+        {
+            added = null;
+            EnsureInitialized();
+            if (axisIndex < 0 || axisIndex >= _axisCount)
+            {
+                if (verbose) Debug.LogWarning($"[WeaponLoadoutRuntime] TryAddPowerUpAt({axisIndex}) — out of range.");
+                return false;
+            }
+            if (powerUp == null)
+            {
+                if (verbose) Debug.LogWarning("[WeaponLoadoutRuntime] TryAddPowerUpAt — powerUpData is null.");
+                return false;
+            }
+            var axis = _axes[axisIndex];
+            if (axis.HasPowerUp)
+            {
+                if (verbose) Debug.LogWarning($"[WeaponLoadoutRuntime] TryAddPowerUpAt({axisIndex}) — axis already has power-up '{axis.powerUp.PowerUpId}'.");
+                return false;
+            }
+
+            added = new PowerUpInstanceData
+            {
+                powerUpData = powerUp,
+                level       = 1,
+                rarity      = initialRarity,
+                element     = rolledElement,
+                axisIndex   = axisIndex,
+            };
+            axis.powerUp = added;
+
+            // Apply global stat boost.
+            ApplyPowerUpModifier(added);
+
+            // Couple element onto the axis's weapon (if any).
+            UpdateWeaponElementFromAxis(axisIndex);
+
+            if (verbose) Debug.Log($"<color=magenta>[WeaponLoadoutRuntime]</color> Added power-up '{added.PowerUpId}' to axis {axisIndex} at {initialRarity}, element {rolledElement}.");
+
+            OnPowerUpAdded?.Invoke(added);
+            MusicEventBus.Fire(MusicEvent.PowerUpAdded, axisIndex);
             return true;
         }
 
         /// <summary>
-        /// Empty the loadout. Called automatically on MusicEvent.RunStart;
-        /// can be called manually for retry / restart flows. Fires
-        /// OnLoadoutCleared + MusicEvent.LoadoutCleared.
+        /// Remove the power-up from the given axis. Removes the global stat
+        /// modifier and decouples the element from the axis's weapon.
+        /// Returns false if the axis has no power-up.
+        ///
+        /// (Per current design, replacement is disallowed — see CLAUDE.md
+        /// M8 design notes — but this method exists for future use and
+        /// for clean teardown on run end.)
+        /// </summary>
+        public bool RemovePowerUp(int axisIndex)
+        {
+            var axis = GetAxis(axisIndex);
+            if (axis == null || !axis.HasPowerUp) return false;
+
+            var p = axis.powerUp;
+            RemovePowerUpModifier(p);
+            axis.powerUp = null;
+
+            // Decouple element — axis's weapon falls back to Neutral.
+            UpdateWeaponElementFromAxis(axisIndex);
+
+            if (verbose) Debug.Log($"<color=magenta>[WeaponLoadoutRuntime]</color> Removed power-up '{p.PowerUpId}' from axis {axisIndex}.");
+
+            OnPowerUpRemoved?.Invoke(axisIndex);
+            MusicEventBus.Fire(MusicEvent.PowerUpRemoved, axisIndex);
+            return true;
+        }
+
+        /// <summary>Bump a power-up's Level by 1 (capped at 5).</summary>
+        public bool LevelUpPowerUp(int axisIndex)
+        {
+            var p = GetPowerUp(axisIndex);
+            if (p == null) return false;
+            if (p.level >= 5) return false;
+
+            p.level++;
+            if (verbose) Debug.Log($"<color=magenta>[WeaponLoadoutRuntime]</color> Axis {axisIndex} power-up '{p.PowerUpId}' L{p.level - 1} → L{p.level}.");
+
+            // Magnitude unchanged in M8 step 1 (level scaling not yet wired).
+            // When step 2 lands and level adjusts magnitude, refresh the
+            // modifier here.
+
+            OnPowerUpLevelChanged?.Invoke(axisIndex);
+            MusicEventBus.Fire(MusicEvent.PowerUpLevelChanged, axisIndex);
+            return true;
+        }
+
+        /// <summary>
+        /// Bump a power-up's Rarity by N tiers (clamped at Legendary).
+        /// Refreshes the global stat modifier with the new magnitude.
+        /// </summary>
+        public bool UpgradePowerUpRarity(int axisIndex, int tiers = 1)
+        {
+            var p = GetPowerUp(axisIndex);
+            if (p == null) return false;
+
+            var oldRarity = p.rarity;
+            var newRarity = RarityRollService.UpgradeBy(oldRarity, tiers);
+            if (newRarity == oldRarity) return true;
+
+            p.rarity = newRarity;
+
+            // Refresh modifier — old removed, new applied.
+            RemovePowerUpModifier(p);
+            ApplyPowerUpModifier(p);
+
+            if (verbose) Debug.Log($"<color=magenta>[WeaponLoadoutRuntime]</color> Axis {axisIndex} power-up '{p.PowerUpId}' rarity {oldRarity} → {newRarity}.");
+
+            OnPowerUpRarityChanged?.Invoke(axisIndex);
+            MusicEventBus.Fire(MusicEvent.PowerUpRarityChanged, axisIndex);
+            return true;
+        }
+
+        // ─── Element coupling ────────────────────────────────────────────
+
+        private void UpdateWeaponElementFromAxis(int axisIndex)
+        {
+            var axis = _axes[axisIndex];
+            if (!axis.HasWeapon) return;
+
+            var newElement = axis.HasPowerUp ? axis.powerUp.element : ElementId.None;
+            if (axis.weapon.element == newElement) return;
+
+            var oldElement = axis.weapon.element;
+            axis.weapon.element = newElement;
+
+            if (verbose) Debug.Log($"<color=magenta>[WeaponLoadoutRuntime]</color> Axis {axisIndex} weapon element {oldElement} → {newElement}.");
+
+            OnWeaponElementChanged?.Invoke(axisIndex);
+            MusicEventBus.Fire(MusicEvent.WeaponElementChanged, axisIndex);
+        }
+
+        // ─── Stat modifier wiring ────────────────────────────────────────
+
+        private void ApplyPowerUpModifier(PowerUpInstanceData p)
+        {
+            var stats = GetPlayerStats();
+            if (stats == null)
+            {
+                if (verbose) Debug.LogWarning("[WeaponLoadoutRuntime] No PlayerStats found in scene — power-up stat boost not applied.");
+                return;
+            }
+            var mod = new StatModifier(
+                type:     p.powerUpData.affectedStat,
+                kind:     ModifierKind.AddPercent,
+                value:    p.CurrentMagnitude, // decimal fraction
+                sourceId: p.ModifierSourceId);
+            stats.AddModifier(mod);
+
+            if (verbose) Debug.Log($"<color=magenta>[WeaponLoadoutRuntime]</color> Applied modifier: {p.powerUpData.affectedStat} +{p.CurrentMagnitude * 100f:F0}% from {p.ModifierSourceId}.");
+        }
+
+        private void RemovePowerUpModifier(PowerUpInstanceData p)
+        {
+            var stats = GetPlayerStats();
+            if (stats == null) return;
+            int removed = stats.RemoveModifiersFromSource(p.ModifierSourceId);
+            if (verbose && removed > 0) Debug.Log($"<color=magenta>[WeaponLoadoutRuntime]</color> Removed {removed} modifier(s) from {p.ModifierSourceId}.");
+        }
+
+        // ─── Run lifecycle ───────────────────────────────────────────────
+
+        /// <summary>
+        /// Set the axis count for this run. Must be called before any axis
+        /// operations (typically by the run bootstrap). Clamped to
+        /// [1, MaxAxisCount]. Re-allocates the internal array; any existing
+        /// state is wiped (emits OnLoadoutCleared).
+        /// </summary>
+        public void SetAxisCount(int count)
+        {
+            count = Mathf.Clamp(count, 1, MaxAxisCount);
+            if (_axes != null && _axisCount == count) return;
+
+            ClearLoadout(); // tear down any existing modifiers first
+            _axisCount = count;
+            _axes = new LoadoutAxis[count];
+            for (int i = 0; i < count; i++)
+            {
+                _axes[i] = new LoadoutAxis { axisIndex = i };
+            }
+            if (verbose) Debug.Log($"[WeaponLoadoutRuntime] Axis count set to {count}.");
+        }
+
+        /// <summary>
+        /// Empty the loadout (all weapons, all power-ups, all stat modifiers).
+        /// Safe to call at any point — idempotent.
         /// </summary>
         public void ClearLoadout()
         {
-            if (_slots.Count == 0) return;
-            _slots.Clear();
-            if (verbose) Debug.Log("<color=cyan>[WeaponLoadoutRuntime]</color> Loadout cleared.");
+            EnsureInitialized();
 
+            bool hadAnything = false;
+            for (int i = 0; i < _axisCount; i++)
+            {
+                var axis = _axes[i];
+                if (axis.HasPowerUp)
+                {
+                    RemovePowerUpModifier(axis.powerUp);
+                    axis.powerUp = null;
+                    hadAnything = true;
+                }
+                if (axis.HasWeapon)
+                {
+                    axis.weapon = null;
+                    hadAnything = true;
+                }
+            }
+
+            if (!hadAnything) return;
+
+            if (verbose) Debug.Log("<color=cyan>[WeaponLoadoutRuntime]</color> Loadout cleared.");
             OnLoadoutCleared?.Invoke();
             MusicEventBus.Fire(MusicEvent.LoadoutCleared);
         }
 
-        // ─── Lifecycle ────────────────────────────────────────────────────
+        // ─── Lifecycle ───────────────────────────────────────────────────
 
         protected override void OnManagerEnabled()
         {
             base.OnManagerEnabled();
-            // Process-global static — no scene-spawn timing concerns. Same
-            // pattern as LevelUpCoordinator (per CLAUDE.md foot-guns).
+            EnsureInitialized();
+            // Process-global static — no scene-spawn timing concerns.
             MusicEventBus.OnEvent += HandleMusicEvent;
         }
 
@@ -353,26 +736,24 @@ namespace CyberPickle.Gameplay.Weapons
         protected override void OnManagerDestroyed()
         {
             base.OnManagerDestroyed();
-            // Defensive — Disable should have unsubscribed already, but a
-            // belt-and-braces detach prevents leaks if Disable was skipped.
             MusicEventBus.OnEvent -= HandleMusicEvent;
+        }
+
+        private void EnsureInitialized()
+        {
+            if (_axes != null) return;
+            _axes = new LoadoutAxis[_axisCount];
+            for (int i = 0; i < _axisCount; i++)
+            {
+                _axes[i] = new LoadoutAxis { axisIndex = i };
+            }
         }
 
         private void HandleMusicEvent(MusicEvent ev, object payload)
         {
-            // 2026-05-10: REMOVED auto-clear on RunStart.
-            //
-            // Why: PlayerLoadoutLoader.OnEnable populates the loadout when
-            // GameSceneBootstrap activates the player components. Then the
-            // bootstrap calls RunStateManager.TransitionTo(Running), which
-            // fires MusicEvent.RunStart. If we cleared on RunStart, we'd
-            // wipe the weapons that PlayerLoadoutLoader just added — the
-            // HUD would then show an empty loadout despite the player
-            // visually having weapons in their hand. (Real bug, debugged
-            // via MCP introspection in M7.4 Day 3.)
-            //
-            // Caller responsibility: PlayerLoadoutLoader.LoadAndSpawn calls
-            // ClearLoadout() at the top to handle retry-without-scene-reload.
+            // 2026-05-10: still no auto-clear on RunStart — see M7.4 Day 3
+            // notes (PlayerLoadoutLoader.LoadAndSpawn calls ClearLoadout()
+            // explicitly at the top to handle retry-without-scene-reload).
             // The Manager<T> being scene-bound (PersistAcrossScenes=>false)
             // also ensures fresh state on scene load.
         }

--- a/Assets/_CyberPickle/Code/Shop/Equipment/Data/PowerUpData.cs
+++ b/Assets/_CyberPickle/Code/Shop/Equipment/Data/PowerUpData.cs
@@ -1,314 +1,155 @@
-// File: Assets/Code/Shop/Equipment/Data/PowerUpData.cs
+// File: Assets/_CyberPickle/Code/Shop/Equipment/Data/PowerUpData.cs
+// Namespace: CyberPickle.Shop.Equipment.Data
 //
-// Purpose: Defines the data structure for power-ups in Cyber Pickle.
-// Contains power-up effects and their scaling with upgrade levels.
-// Supports synergies with weapons to unlock final weapon forms.
+// Defines a power-up template — the design data for one type of stat
+// boost. Each power-up has TWO orthogonal characteristics:
 //
-// Created: 2025-02-25
-// Updated: 2025-02-25
+//   1. Stat type + magnitude curve (authored on the SO)
+//        Which PlayerStatType this power-up boosts, and by how much at
+//        each rarity tier. Magnitudes are decimal fractions (0.10 = +10%)
+//        per the AddPercent foot-gun rule (CLAUDE.md).
+//
+//   2. Element (rolled at draft time)
+//        Which of the 7 elements this card-instance carries. Same
+//        template ("Fire-Rate Boost") shows up as Fire / Lightning /
+//        Ice / etc. variants in the draft pool. The element confers to
+//        the WEAPON on the same loadout axis when slotted (and only
+//        applies if a weapon is present).
+//
+// The stat bonus is GLOBAL — applies to all weapons regardless of which
+// axis the power-up sits on. Element coupling is LOCAL to the axis.
+//
+// 2026-05-10 refactor (M8): the previous shape (effectType,
+// baseDuration / baseCooldown, GetXForLevel multipliers, IsCompatibleWithWeapon)
+// was the "old amulet/synergy" model dropped in GDD V0.7. All replaced
+// by: PlayerStatType + 5-element magnitudesByRarity[]. Element no longer
+// authored — rolled at draft time per weapon_rarity_v1.md.
 
 using UnityEngine;
-using System;
-using System.Collections.Generic;
+using CyberPickle.Core;
 using CyberPickle.Core.Services.Authentication.Data;
+using CyberPickle.Gameplay.Stats;
 
 namespace CyberPickle.Shop.Equipment.Data
 {
     /// <summary>
-    /// Defines the type of effect a power-up provides
-    /// </summary>
-    public enum PowerUpEffectType
-    {
-        StatBoost,      // Directly boosts a character stat
-        WeaponBoost,    // Enhances weapon performance
-        SpecialEffect,  // Provides a special gameplay effect
-        DefensiveAbility, // Provides a defensive ability
-        PassiveAbility  // Provides a passive ability
-    }
-
-    /// <summary>
-    /// Scriptable Object that defines data for power-up equipment
+    /// ScriptableObject defining one power-up template. The asset stores
+    /// the stat target + per-rarity magnitude curve; the element is rolled
+    /// at draft time onto a runtime <c>PowerUpInstanceData</c>.
     /// </summary>
     [CreateAssetMenu(fileName = "PowerUp", menuName = "CyberPickle/Equipment/PowerUpData")]
     public class PowerUpData : EquipmentData
     {
-        [Header("Power-Up Properties")]
-        [Tooltip("The type of effect this power-up provides")]
-        public PowerUpEffectType effectType = PowerUpEffectType.StatBoost;
+        [Header("Stat Boost (the GLOBAL effect applied to all weapons)")]
+        [Tooltip("Which player stat this power-up boosts. The bonus is global — it applies to every weapon, not just the weapon on the same axis. Element coupling (which IS per-axis) is rolled at draft time and lives on the runtime PowerUpInstanceData, not here.")]
+        public PlayerStatType affectedStat = PlayerStatType.Power;
 
-        [Tooltip("Duration of the effect in seconds (0 = permanent)")]
-        public float baseDuration = 0f;
+        [Tooltip(
+            "Magnitude per rarity tier as a DECIMAL FRACTION (0.10 = +10%).\n" +
+            "Index 0 = Common, 1 = Uncommon, 2 = Rare, 3 = Epic, 4 = Legendary.\n\n" +
+            "Per-stat curves are intentional: a Fire-Rate power-up at Legendary " +
+            "(+25%) is fine, but a Crit-Chance power-up at Legendary (+25%) is " +
+            "absurd. Each stat gets its own progression authored independently.\n\n" +
+            "If unset, defaults to {0.05, 0.08, 0.12, 0.18, 0.25} — a reasonable " +
+            "starting curve. Override per asset for stat-specific tuning.")]
+        public float[] magnitudesByRarity = new float[]
+        {
+            0.05f, // Common
+            0.08f, // Uncommon
+            0.12f, // Rare
+            0.18f, // Epic
+            0.25f, // Legendary
+        };
 
-        [Tooltip("Cooldown before the power-up can be activated again (0 = passive effect)")]
-        public float baseCooldown = 0f;
+        [Header("Visual & Audio (optional)")]
+        [Tooltip("VFX prefab spawned briefly when this power-up is slotted onto an axis. Optional — placeholder visuals work for prototyping.")]
+        public GameObject slotEffectPrefab;
 
-        [Tooltip("Is this power-up automatically activated or manually triggered?")]
-        public bool isPassive = true;
+        [Tooltip("Sound played when this power-up is slotted. Optional.")]
+        public AudioClip slotSound;
 
-        [Header("Stat Boosts")]
-        [Tooltip("The stat this power-up affects (if applicable)")]
-        public string affectedStat = "Power";
-
-        [Tooltip("Base amount to boost the stat by")]
-        public float baseStatBoost = 10f;
-
-        [Tooltip("Is the stat boost a flat value (false) or percentage (true)?")]
-        public bool isPercentageBased = true;
-
-        [Header("Weapon Enhancement")]
-        [Tooltip("Compatible weapon types for enhanced effects")]
-        public EquipmentSlotType[] compatibleWeaponTypes;
-
-        [Tooltip("Weapon IDs that have special synergy with this power-up")]
-        public string[] synergisticWeaponIds;
-
-        [Tooltip("Weapon properties affected by this power-up")]
-        public string[] affectedWeaponProperties;
-
-        [Tooltip("Base multiplier for weapon enhancement")]
-        public float baseWeaponEnhancementMultiplier = 1.2f;
-
-        [Header("Special Effects")]
-        [Tooltip("Description of special effects for level 1")]
-        [TextArea(2, 5)]
-        public string baseEffectDescription;
-
-        [Tooltip("Description of special effects for max level")]
-        [TextArea(2, 5)]
-        public string maxLevelEffectDescription;
-
-        [Header("Visual & Audio")]
-        [Tooltip("VFX prefab for when the power-up is active")]
-        public GameObject activeEffectPrefab;
-
-        [Tooltip("Sound effect for activation")]
-        public AudioClip activationSound;
-
-        [Header("Upgrade Scaling")]
-        [Tooltip("Effect strength increase per level (multiplier)")]
-        [Range(1f, 2f)]
-        public float effectStrengthUpgradeMultiplier = 1.2f;
-
-        [Tooltip("Duration increase per level (multiplier)")]
-        [Range(1f, 1.5f)]
-        public float durationUpgradeMultiplier = 1.15f;
-
-        [Tooltip("Cooldown reduction per level (multiplier)")]
-        [Range(0.5f, 1f)]
-        public float cooldownReductionMultiplier = 0.9f;
+        // ─── API ──────────────────────────────────────────────────────────
 
         /// <summary>
-        /// Validates the power-up data when it's created or modified in the editor.
+        /// Returns the magnitude (decimal fraction; 0.10 = +10%) for the
+        /// given rarity tier. Falls back to a sensible default if the
+        /// authored array is the wrong length.
         /// </summary>
-        protected override void OnValidate()
+        public float GetMagnitudeForRarity(Rarity rarity)
         {
-            // Ensure correct slot type
-            slotType = EquipmentSlotType.PowerUp;
+            int idx = (int)rarity;
+            if (magnitudesByRarity != null && idx >= 0 && idx < magnitudesByRarity.Length)
+                return magnitudesByRarity[idx];
 
-            base.OnValidate();
-
-            // Additional power-up specific validation
-            ValidatePowerUpFields();
-        }
-
-        /// <summary>
-        /// Validates power-up specific fields
-        /// </summary>
-        private void ValidatePowerUpFields()
-        {
-            // Ensure base values are valid
-            baseDuration = Mathf.Max(0f, baseDuration);
-            baseCooldown = Mathf.Max(0f, baseCooldown);
-            baseStatBoost = Mathf.Max(0f, baseStatBoost);
-            baseWeaponEnhancementMultiplier = Mathf.Max(1f, baseWeaponEnhancementMultiplier);
-
-            // Ensure scaling multipliers are in valid ranges
-            effectStrengthUpgradeMultiplier = Mathf.Max(1f, effectStrengthUpgradeMultiplier);
-
-            if (baseDuration > 0)
-                durationUpgradeMultiplier = Mathf.Max(1f, durationUpgradeMultiplier);
-
-            if (baseCooldown > 0)
-                cooldownReductionMultiplier = Mathf.Clamp(cooldownReductionMultiplier, 0.5f, 1f);
-        }
-
-        /// <summary>
-        /// Gets the power-up's effect strength for a specified upgrade level
-        /// </summary>
-        /// <param name="level">Upgrade level of the power-up</param>
-        /// <returns>The effect strength value at that level</returns>
-        public float GetEffectStrengthForLevel(int level)
-        {
-            level = Mathf.Clamp(level, 1, maxUpgradeLevel);
-
-            switch (effectType)
+            // Defensive fallback if the asset wasn't migrated to the new
+            // 5-entry format (e.g., post-refactor, before re-author).
+            return rarity switch
             {
-                case PowerUpEffectType.StatBoost:
-                    return baseStatBoost * Mathf.Pow(effectStrengthUpgradeMultiplier, level - 1);
-
-                case PowerUpEffectType.WeaponBoost:
-                    return baseWeaponEnhancementMultiplier + (0.1f * (level - 1));
-
-                default:
-                    return Mathf.Pow(effectStrengthUpgradeMultiplier, level - 1);
-            }
+                Rarity.Common    => 0.05f,
+                Rarity.Uncommon  => 0.08f,
+                Rarity.Rare      => 0.12f,
+                Rarity.Epic      => 0.18f,
+                Rarity.Legendary => 0.25f,
+                _                => 0.05f,
+            };
         }
 
         /// <summary>
-        /// Gets the power-up's duration for a specified upgrade level
-        /// </summary>
-        /// <param name="level">Upgrade level of the power-up</param>
-        /// <returns>The duration in seconds at that level</returns>
-        public float GetDurationForLevel(int level)
-        {
-            if (baseDuration <= 0) return 0f; // Permanent effect
-
-            level = Mathf.Clamp(level, 1, maxUpgradeLevel);
-            return baseDuration * Mathf.Pow(durationUpgradeMultiplier, level - 1);
-        }
-
-        /// <summary>
-        /// Gets the power-up's cooldown for a specified upgrade level
-        /// </summary>
-        /// <param name="level">Upgrade level of the power-up</param>
-        /// <returns>The cooldown in seconds at that level</returns>
-        public float GetCooldownForLevel(int level)
-        {
-            if (baseCooldown <= 0) return 0f; // No cooldown
-
-            level = Mathf.Clamp(level, 1, maxUpgradeLevel);
-            return baseCooldown * Mathf.Pow(cooldownReductionMultiplier, level - 1);
-        }
-
-        /// <summary>
-        /// Gets a formatted effect description for the specified level
-        /// </summary>
-        /// <param name="level">Upgrade level of the power-up</param>
-        /// <returns>A formatted description of the effect at that level</returns>
-        public string GetEffectDescriptionForLevel(int level)
-        {
-            level = Mathf.Clamp(level, 1, maxUpgradeLevel);
-
-            // For level 1, return the base description
-            if (level == 1)
-                return baseEffectDescription;
-
-            // For max level, return the max level description
-            if (level == maxUpgradeLevel && !string.IsNullOrEmpty(maxLevelEffectDescription))
-                return maxLevelEffectDescription;
-
-            // For intermediate levels, generate a description based on effect type
-            string description = baseEffectDescription;
-
-            // Replace placeholders with actual values
-            description = description.Replace("{strength}", GetEffectStrengthForLevel(level).ToString("F1"));
-            description = description.Replace("{duration}", GetDurationForLevel(level).ToString("F1"));
-            description = description.Replace("{cooldown}", GetCooldownForLevel(level).ToString("F1"));
-
-            return description;
-        }
-
-        /// <summary>
-        /// Gets the stats for the specified upgrade level
+        /// Returns the stats this power-up would impart at the given rarity,
+        /// for tooltip / hover display. The "Level" parameter is unused for
+        /// now — power-up scaling is rarity-only in the M8 model. Kept on
+        /// the override for EquipmentData parity.
         /// </summary>
         public override StatDescriptor[] GetStatsForLevel(int upgradeLevel)
         {
-            upgradeLevel = Mathf.Clamp(upgradeLevel, 1, maxUpgradeLevel);
-
-            List<StatDescriptor> stats = new List<StatDescriptor>();
-
-            // Add stats based on effect type
-            switch (effectType)
+            // 2026-05-10: rarity is the runtime axis, not authored on the asset.
+            // For preview-purposes (e.g., the equipment hub showing what a card
+            // *could* roll), we display the Common-tier magnitude as the
+            // baseline. Actual in-run cards display the rolled rarity's value.
+            float magnitude = GetMagnitudeForRarity(Rarity.Common);
+            return new[]
             {
-                case PowerUpEffectType.StatBoost:
-                    stats.Add(new StatDescriptor(
-                        affectedStat,
-                        GetEffectStrengthForLevel(upgradeLevel),
-                        isPercentageBased,
-                        true
-                    ));
-                    break;
-
-                case PowerUpEffectType.WeaponBoost:
-                    stats.Add(new StatDescriptor(
-                        "Weapon Boost",
-                        (GetEffectStrengthForLevel(upgradeLevel) - 1) * 100f,
-                        true,
-                        true
-                    ));
-                    break;
-
-                case PowerUpEffectType.SpecialEffect:
-                case PowerUpEffectType.DefensiveAbility:
-                case PowerUpEffectType.PassiveAbility:
-                    stats.Add(new StatDescriptor(
-                        "Effect Strength",
-                        GetEffectStrengthForLevel(upgradeLevel) * 100f,
-                        true,
-                        true
-                    ));
-                    break;
-            }
-
-            // Add duration if applicable
-            if (baseDuration > 0)
-            {
-                stats.Add(new StatDescriptor(
-                    "Duration",
-                    GetDurationForLevel(upgradeLevel),
-                    false,
-                    true
-                ));
-            }
-
-            // Add cooldown if applicable
-            if (baseCooldown > 0)
-            {
-                stats.Add(new StatDescriptor(
-                    "Cooldown",
-                    GetCooldownForLevel(upgradeLevel),
-                    false,
-                    false  // Lower is better for cooldown
-                ));
-            }
-
-            return stats.ToArray();
+                new StatDescriptor(
+                    affectedStat.ToString(),
+                    magnitude * 100f, // display as percentage
+                    isPercentage: true,
+                    higherIsBetter: true),
+            };
         }
 
-        /// <summary>
-        /// Determines if this power-up can enhance the specified weapon
-        /// </summary>
-        /// <param name="weaponId">The ID of the weapon to check</param>
-        /// <returns>True if compatible, false otherwise</returns>
-        public bool IsCompatibleWithWeapon(string weaponId)
-        {
-            if (string.IsNullOrEmpty(weaponId))
-                return false;
-
-            // Check if weapon is in synergistic list
-            for (int i = 0; i < synergisticWeaponIds.Length; i++)
-            {
-                if (synergisticWeaponIds[i] == weaponId)
-                    return true;
-            }
-
-            return false;
-        }
+        // ─── Editor validation ────────────────────────────────────────────
 
 #if UNITY_EDITOR
-        /// <summary>
-        /// Validates required references are assigned in the editor
-        /// </summary>
-        public override bool ValidateReferences()
+        protected override void OnValidate()
         {
-            bool valid = base.ValidateReferences();
+            slotType = EquipmentSlotType.PowerUp;
+            base.OnValidate();
 
-            if (activationSound == null && !isPassive)
+            // Magnitudes are decimal fractions — anything > 1.0 is almost
+            // always a designer who typed "10" thinking "10%". Catch at
+            // edit time. Same foot-gun guard as UpgradeCardSO.OnValidate.
+            if (magnitudesByRarity == null) return;
+            for (int i = 0; i < magnitudesByRarity.Length; i++)
             {
-                Debug.LogWarning($"[PowerUpData] Activation sound is missing for non-passive power-up {displayName}");
+                if (Mathf.Abs(magnitudesByRarity[i]) > 1.0f)
+                {
+                    Debug.LogWarning(
+                        $"[PowerUpData] '{name}' magnitudesByRarity[{i}]={magnitudesByRarity[i]}. " +
+                        $"This is a DECIMAL FRACTION (0.10 = +10%); a value > 1.0 means > +100%, " +
+                        $"which is rarely intentional. If you meant +{magnitudesByRarity[i]}%, " +
+                        $"set the value to {magnitudesByRarity[i] / 100f:F2} instead.",
+                        this);
+                }
             }
 
-            return valid;
+            if (magnitudesByRarity.Length != 5)
+            {
+                Debug.LogWarning(
+                    $"[PowerUpData] '{name}' magnitudesByRarity has {magnitudesByRarity.Length} entries; " +
+                    $"5 are expected (one per rarity tier Common..Legendary). The runtime will fall " +
+                    $"back to the default curve for missing entries.",
+                    this);
+            }
         }
 #endif
     }

--- a/Assets/_CyberPickle/Code/Shop/Equipment/Data/WeaponData.cs
+++ b/Assets/_CyberPickle/Code/Shop/Equipment/Data/WeaponData.cs
@@ -47,6 +47,18 @@ namespace CyberPickle.Shop.Equipment.Data
     }
 
     /// <summary>
+    /// How a projectile moves between muzzle and impact (M9 PR A).
+    /// </summary>
+    public enum ProjectileTrajectory : byte
+    {
+        /// <summary>Linear flight along the muzzle's forward vector at <c>baseProjectileSpeed</c>. Default for pistol / shotgun / sniper.</summary>
+        Straight = 0,
+
+        /// <summary>Ballistic parabolic arc that lands at the target after <c>flightBeats × 60 / BPM</c> seconds. Real gravity drives the arc — launch angle is steep at close range, shallow at far range, apex height depends only on flight time. Grenade launcher.</summary>
+        Parabolic = 1,
+    }
+
+    /// <summary>
     /// ScriptableObject that defines data for weapon equipment
     /// </summary>
     [CreateAssetMenu(fileName = "Weapon", menuName = "CyberPickle/Equipment/WeaponData")]
@@ -74,8 +86,14 @@ namespace CyberPickle.Shop.Equipment.Data
         [Tooltip("Base pierce count (0 = no pierce). May be augmented by per-rarity-tier perks (e.g., Legendary 'pierces all').")]
         public int basePierceCount = 0;
 
-        [Header("Audio & VFX")]
-        [Tooltip("Prefab for projectile or attack VFX")]
+        [Header("Audio & VFX (legacy — moved to ElementVfxLibrary in M9)")]
+        [Tooltip(
+            "LEGACY — kept for back-compat with weapons authored before M9. " +
+            "Production weapons read their visual prefabs from the global " +
+            "ElementVfxLibrary (keyed by the rolled element on the loadout axis). " +
+            "This field is only consulted as a fallback when the library can't " +
+            "resolve a prefab for the current element. Leave assigned during the " +
+            "M9 transition; safe to clear once the library covers all elements.")]
         public GameObject projectilePrefab;
 
         [Tooltip("Sound effect for firing")]
@@ -84,8 +102,57 @@ namespace CyberPickle.Shop.Equipment.Data
         [Tooltip("Sound effect for hitting")]
         public AudioClip hitSound;
 
-        [Tooltip("VFX prefab for hit effect")]
+        [Tooltip("LEGACY — see projectilePrefab note. Fallback only. M9+ reads hit prefab from ElementVfxLibrary.")]
         public GameObject hitEffectPrefab;
+
+        // ─── M9: per-weapon behavior + VFX scaling ────────────────────────
+
+        [Header("Behavior & VFX Scaling (M9 — per-weapon variation layer)")]
+        [Tooltip(
+            "Maximum targeting range (world units). Used by WeaponTargeting to " +
+            "ignore enemies further than this. Per-weapon so pistols snap close " +
+            "(~12), shotguns very close (~8), sniper long (~25), grenade mid (~18).")]
+        [Min(1f)] public float baseRange = 15f;
+
+        [Tooltip(
+            "Uniform scale multiplier on the muzzle flash GameObject spawned at " +
+            "fire-time. The flash visual itself comes from ElementVfxLibrary " +
+            "(matching the weapon's currently-coupled element). Use this to make " +
+            "heavy weapons (grenade launcher) flash bigger, light weapons (pistol) " +
+            "flash subtler. 1.0 = library default.")]
+        [Min(0f)] public float muzzleFlashScale = 1f;
+
+        [Tooltip(
+            "Uniform scale multiplier on the projectile visual. Heavy weapons " +
+            "(grenade launcher) want bigger projectiles. 1.0 = library default.")]
+        [Min(0f)] public float projectileScale = 1f;
+
+        [Tooltip(
+            "Uniform scale multiplier on the hit VFX spawned on collision. " +
+            "Composed with damage-scale and crit-scale at hit time (M9 PR F). " +
+            "1.0 = library default.")]
+        [Min(0f)] public float hitVfxScale = 1f;
+
+        [Tooltip(
+            "If true, the hit VFX is ADDITIONALLY scaled by the runtime AoE " +
+            "radius (baseAreaOfEffect × PlayerStats.AreaOfEffect). Set true for " +
+            "weapons whose explosion should visibly fill the damage zone " +
+            "(grenade launcher). Leave false for point-impact weapons.")]
+        public bool hitVfxScalesWithAreaOfEffect = false;
+
+        [Tooltip(
+            "How the projectile moves through space. Straight = standard auto-aimed " +
+            "linear flight (pistol / shotgun / sniper). Parabolic = ballistic arc " +
+            "lobbed at a fixed flight time (grenade launcher). Parabolic uses the " +
+            "current music BPM via MusicConductor; flight time = flightBeats × 60 / BPM.")]
+        public ProjectileTrajectory trajectory = ProjectileTrajectory.Straight;
+
+        [Tooltip(
+            "Parabolic only — number of musical beats between launch and impact. " +
+            "Default 1 (fire on beat N, explode on beat N+1). Grenade launcher " +
+            "uses 2 (fire on beat 1, lands on beat 3 — the classic kick-kick " +
+            "tick-tock backbone of 4/4). Set higher (3, 4) for slow mortar arcs.")]
+        [Min(1)] public int flightBeats = 1;
 
         [Header("Pattern (Level → fire rate, see procedural_music_reference.md §22)")]
         [Tooltip("Active-cell count per weapon level (1..5). Index 0 = L1, index 4 = L5. Each entry is the number of cells with active=1 in the weapon's 4-bar × 32-subdivision pattern (max 128). Effective fire rate = activeCells / patternDuration, where patternDuration = barCount × beatsPerBar × 60 / BPM. Example: 4 active cells in a 4-bar pattern at 120 BPM → 4 / 8s = 0.5 shots/sec (very sparse, good for L1 of a heavy weapon).")]

--- a/Assets/_CyberPickle/Code/Shop/Equipment/Data/WeaponData.cs
+++ b/Assets/_CyberPickle/Code/Shop/Equipment/Data/WeaponData.cs
@@ -107,8 +107,15 @@ namespace CyberPickle.Shop.Equipment.Data
         [Tooltip("Required power-up ID to unlock final form")]
         public string requiredPowerUpId;
 
-        [Header("Element (default — see procedural_music_reference.md §22.4)")]
-        [Tooltip("Default element this weapon enters the loadout with. Drives the weapon's pre-evolution musical mode (Fire = Phrygian Dominant, Ice = Aeolian, etc.). Locked to a new value at evolution if a power-up of a different element triggers it. ElementId.None means 'no element assigned' — used for elementally-neutral weapons or testing.")]
+        [Header("Element — TEST-ONLY (see procedural_music_reference.md §22.4)")]
+        [Tooltip(
+            "TEST-ONLY default element. Production weapons start NEUTRAL " +
+            "(ElementId.None) and only acquire an element when a power-up " +
+            "is slotted on the same loadout axis (M8 element coupling). " +
+            "This field exists for editor / preview / unit-test scenarios " +
+            "where you want a weapon to fire with a specific element without " +
+            "going through the full power-up coupling flow. Leave as None " +
+            "for any weapon shipping in a real run.")]
         public ElementId defaultElement = ElementId.None;
 
         // ─── Dual-axis: Rarity tier perks ─────────────────────────────────

--- a/Assets/_CyberPickle/Code/UI/HUD/LoadoutCrossPanel.cs
+++ b/Assets/_CyberPickle/Code/UI/HUD/LoadoutCrossPanel.cs
@@ -26,6 +26,7 @@
 //     SetAxisCount before any axis operations).
 
 using System;
+using DG.Tweening;
 using UnityEngine;
 using UnityEngine.UI;
 using CyberPickle.Gameplay.Audio;
@@ -68,7 +69,7 @@ namespace CyberPickle.UI.HUD
         [SerializeField] private Color slotPickerEligibleColor = new Color(0.40f, 0.95f, 1.00f, 0.60f);
 
         [Header("State / Layout")]
-        [Tooltip("RectTransform of the panel. Auto-fetched if null. Used by SetState to reposition between Compact and Expanded — currently instant; M8 step 5 adds DOTween animation.")]
+        [Tooltip("RectTransform of the panel. Auto-fetched if null. Used by SetState to reposition between Compact and Expanded.")]
         [SerializeField] private RectTransform rect;
 
         [Tooltip("Anchored position when in Compact (in-game HUD) state. Typically a screen corner.")]
@@ -82,6 +83,17 @@ namespace CyberPickle.UI.HUD
 
         [Tooltip("Local scale when in Expanded state. Larger so the cross dominates the screen during the modal.")]
         [SerializeField] private Vector3 expandedScale = new Vector3(1.6f, 1.6f, 1f);
+
+        [Header("Card Spawn Area (Expanded state)")]
+        [Tooltip("RectTransform at the center of the cross where the level-up modal spawns its cards. The level-up controller reparents card slots here when the cross is in Expanded state. Optional — leave null for the legacy non-cross modal layout.")]
+        [SerializeField] private RectTransform cardSpawnContainer;
+
+        [Header("Animation")]
+        [Tooltip("Seconds the Compact ↔ Expanded tween runs. Uses unscaled time so it animates while the game is paused (Time.timeScale=0 during LevelUpPaused). Set to 0 to disable animation (snap instantly).")]
+        [Min(0f)] [SerializeField] private float stateTweenDuration = 0.45f;
+
+        [Tooltip("Easing applied to the Compact ↔ Expanded tween.")]
+        [SerializeField] private Ease stateTweenEase = Ease.OutBack;
 
         [Header("Diagnostics")]
         [SerializeField] private bool verbose = false;
@@ -108,13 +120,23 @@ namespace CyberPickle.UI.HUD
         public event Action OnSlotPickerCancelled;
 
         /// <summary>
-        /// Set the cross's visual state (Compact ↔ Expanded). Currently
-        /// instant — DOTween animation lands in M8 step 5.
+        /// RectTransform at the center of the cross where the level-up modal
+        /// spawns its cards in Expanded state. Null if the cross isn't
+        /// configured as a card host (e.g., legacy non-cross modal layout).
         /// </summary>
-        public void SetState(CrossState state)
+        public RectTransform CardSpawnContainer => cardSpawnContainer;
+
+        /// <summary>
+        /// Set the cross's visual state (Compact ↔ Expanded). Tweens
+        /// position + scale via DOTween with unscaled time, so it animates
+        /// during LevelUpPaused (Time.timeScale = 0). If
+        /// <paramref name="animated"/> is false (or stateTweenDuration is 0),
+        /// the state snaps instantly.
+        /// </summary>
+        public void SetState(CrossState state, bool animated = true)
         {
             State = state;
-            ApplyState();
+            ApplyState(animated);
         }
 
         /// <summary>
@@ -173,7 +195,10 @@ namespace CyberPickle.UI.HUD
             // level via Update + raycasts (simpler than wiring per-slot
             // delegates and tearing them down). See HandleSlotPickerInput.
 
-            ApplyState();
+            // Awake snaps to current state without animating — the prefab's
+            // placement is irrelevant; we want to land exactly at the
+            // compactPosition/Scale before the first frame renders.
+            ApplyState(animated: false);
         }
 
         private void OnEnable()
@@ -185,6 +210,14 @@ namespace CyberPickle.UI.HUD
         {
             MusicEventBus.OnEvent -= HandleMusicEvent;
             UnbindLoadout();
+            _posTween?.Kill();
+            _scaleTween?.Kill();
+        }
+
+        private void OnDestroy()
+        {
+            _posTween?.Kill();
+            _scaleTween?.Kill();
         }
 
         private void HandleMusicEvent(MusicEvent type, object payload)
@@ -287,19 +320,111 @@ namespace CyberPickle.UI.HUD
 
         // ─── State (Compact / Expanded) ─────────────────────────────────
 
-        private void ApplyState()
+        private Tween _posTween;
+        private Tween _scaleTween;
+
+        private void ApplyState(bool animated = true)
         {
             if (rect == null) return;
+
+            Vector2 targetPos;
+            Vector3 targetScale;
             switch (State)
             {
                 case CrossState.Compact:
-                    rect.anchoredPosition = compactPosition;
-                    rect.localScale       = compactScale;
+                    targetPos   = compactPosition;
+                    targetScale = compactScale;
                     break;
                 case CrossState.Expanded:
-                    rect.anchoredPosition = expandedPosition;
-                    rect.localScale       = expandedScale;
+                    targetPos   = expandedPosition;
+                    targetScale = expandedScale;
                     break;
+                default:
+                    return;
+            }
+
+            // Kill any in-flight tweens so we don't fight an old animation.
+            _posTween?.Kill();
+            _scaleTween?.Kill();
+
+            if (!animated || stateTweenDuration <= 0f)
+            {
+                rect.anchoredPosition = targetPos;
+                rect.localScale       = targetScale;
+                return;
+            }
+
+            // SetUpdate(true) → use unscaled time so the tween runs even when
+            // Time.timeScale = 0 (LevelUpPaused). Same defensive pattern as
+            // the existing CharacterIconWidget / TooltipController fades.
+            _posTween   = rect.DOAnchorPos(targetPos, stateTweenDuration)
+                              .SetEase(stateTweenEase)
+                              .SetUpdate(true);
+            _scaleTween = rect.DOScale(targetScale, stateTweenDuration)
+                              .SetEase(stateTweenEase)
+                              .SetUpdate(true);
+        }
+
+        // ─── Commit animation (stat-pip fly-to-core) ────────────────────
+
+        [Header("Commit animation")]
+        [Tooltip("Pip prefab spawned during PlayCommitAnimation — one per stat magnitude unit. Optional. If null, the animation is a no-op (no visual feedback). Designer can wire a small Image or particle prefab here.")]
+        [SerializeField] private RectTransform commitPipPrefab;
+
+        [Tooltip("Pip flight duration (unscaled). Pips are tinted by the rolled element + tweened from a source position to the cross center.")]
+        [Min(0f)] [SerializeField] private float commitPipDuration = 0.7f;
+
+        [Tooltip("Easing curve for the commit pip flight. AnimationCurve so designers can author bursts/arcs in the inspector.")]
+        [SerializeField] private Ease commitPipEase = Ease.InQuad;
+
+        /// <summary>
+        /// Plays the "stat magnitude pips fly into the cross core"
+        /// animation. The level-up screen calls this just before fading out
+        /// after a card is committed — visual feedback that the modifiers
+        /// were absorbed by the build.
+        ///
+        /// <paramref name="fromScreenPos"/> is where the pips spawn (the
+        /// committed card's position). <paramref name="elementColor"/>
+        /// tints the pips. <paramref name="pipCount"/> controls density
+        /// (caller can scale by rarity / magnitude for richer feedback).
+        ///
+        /// No-op if <c>commitPipPrefab</c> isn't assigned.
+        /// </summary>
+        public void PlayCommitAnimation(Vector2 fromScreenPos, Color elementColor, int pipCount = 5)
+        {
+            if (commitPipPrefab == null) return;
+            if (cardSpawnContainer == null && rect == null) return;
+
+            var center = cardSpawnContainer != null ? cardSpawnContainer : rect;
+            var canvas = GetComponentInParent<Canvas>();
+            var canvasRt = canvas != null ? (RectTransform)canvas.transform : null;
+            if (canvasRt == null) return;
+
+            var cam = canvas.renderMode == RenderMode.ScreenSpaceOverlay ? null : canvas.worldCamera;
+            // Convert screen positions to canvas-local so we can lerp in
+            // local space (preserves anchor + scale handling).
+            RectTransformUtility.ScreenPointToLocalPointInRectangle(canvasRt, fromScreenPos, cam, out var fromLocal);
+            Vector2 toScreen = RectTransformUtility.WorldToScreenPoint(cam, center.position);
+            RectTransformUtility.ScreenPointToLocalPointInRectangle(canvasRt, toScreen, cam, out var toLocal);
+
+            for (int i = 0; i < Mathf.Max(1, pipCount); i++)
+            {
+                var pip = Instantiate(commitPipPrefab, canvasRt);
+                pip.gameObject.SetActive(true);
+                // Slight random offset so the pips spread out a bit.
+                Vector2 jitter = UnityEngine.Random.insideUnitCircle * 12f;
+                pip.anchoredPosition = fromLocal + jitter;
+
+                // Tint: any Graphic on the pip gets element-colored.
+                var graphic = pip.GetComponent<Graphic>();
+                if (graphic != null) graphic.color = elementColor;
+
+                float delay = i * 0.04f; // staggered launch
+                pip.DOAnchorPos(toLocal, commitPipDuration)
+                   .SetDelay(delay)
+                   .SetEase(commitPipEase)
+                   .SetUpdate(true)
+                   .OnComplete(() => { if (pip != null) Destroy(pip.gameObject); });
             }
         }
 

--- a/Assets/_CyberPickle/Code/UI/HUD/LoadoutCrossPanel.cs
+++ b/Assets/_CyberPickle/Code/UI/HUD/LoadoutCrossPanel.cs
@@ -1,0 +1,416 @@
+// File: Assets/_CyberPickle/Code/UI/HUD/LoadoutCrossPanel.cs
+// Namespace: CyberPickle.UI.HUD
+//
+// The cross-shaped loadout HUD. Replaces WeaponSlotsPanel — instead of a
+// horizontal row of 4 weapon slots, this widget owns 4 weapon slots + 4
+// power-up slots arranged as a cross (one weapon + one power-up per axis).
+//
+// Per chat 2026-05-11, the same widget acts as both the in-game HUD AND
+// the level-up modal's slot picker — when a NewWeapon or NewPowerUp card
+// is picked, the panel enters slot-picker mode (empty eligible slots
+// highlight, the player clicks one to commit). Animation between compact
+// and expanded states is M8 step 5 polish — for step 4 we just toggle
+// SetState(Compact|Expanded) instantaneously.
+//
+// Tooltips are preserved per the user's request: each cell is a
+// HoverableElement (WeaponSlotUI / PowerUpSlotUI) so hover shows the
+// existing tooltip behavior — including the lock-on-hover slider for
+// weapon slots (which have live DPS).
+//
+// Authoring:
+//   - Drop this on a parent GameObject under the HUD canvas.
+//   - Set weaponSlots[0..N-1] to the WeaponSlotUI children, ordered by axis index.
+//   - Set powerUpSlots[0..N-1] to the PowerUpSlotUI children, ordered by axis index.
+//   - The two arrays must be the SAME LENGTH and that length must match
+//     the runtime axis count (default 4; configurable via the loadout's
+//     SetAxisCount before any axis operations).
+
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+using CyberPickle.Gameplay.Audio;
+using CyberPickle.Gameplay.Weapons;
+
+namespace CyberPickle.UI.HUD
+{
+    [DisallowMultipleComponent]
+    public class LoadoutCrossPanel : MonoBehaviour
+    {
+        public enum CrossState
+        {
+            /// <summary>Default in-game HUD layout — small, anchored to corner.</summary>
+            Compact,
+            /// <summary>Level-up modal layout — larger, centered, ready to host cards in the middle.</summary>
+            Expanded,
+        }
+
+        public enum SlotKind
+        {
+            Weapon,
+            PowerUp,
+        }
+
+        [Header("Slots — ordered by axis index (must be same length)")]
+        [Tooltip("Weapon slots, one per axis. Index = axisIndex. Required.")]
+        [SerializeField] private WeaponSlotUI[] weaponSlots = new WeaponSlotUI[WeaponLoadoutRuntime.DefaultAxisCount];
+
+        [Tooltip("Power-up slots, one per axis. Index = axisIndex. Required and must be the same length as weaponSlots.")]
+        [SerializeField] private PowerUpSlotUI[] powerUpSlots = new PowerUpSlotUI[WeaponLoadoutRuntime.DefaultAxisCount];
+
+        [Header("Slot-picker visuals")]
+        [Tooltip("Glow / highlight image overlaid on each ELIGIBLE empty slot during slot-picker mode. One per axis (matches array length). Optional but recommended for a clear UX cue.")]
+        [SerializeField] private Image[] weaponSlotHighlights;
+
+        [Tooltip("Glow / highlight image overlaid on each ELIGIBLE empty power-up slot during slot-picker mode. One per axis. Optional.")]
+        [SerializeField] private Image[] powerUpSlotHighlights;
+
+        [Tooltip("Color for highlighted (eligible) slots during slot-picker mode.")]
+        [SerializeField] private Color slotPickerEligibleColor = new Color(0.40f, 0.95f, 1.00f, 0.60f);
+
+        [Header("State / Layout")]
+        [Tooltip("RectTransform of the panel. Auto-fetched if null. Used by SetState to reposition between Compact and Expanded — currently instant; M8 step 5 adds DOTween animation.")]
+        [SerializeField] private RectTransform rect;
+
+        [Tooltip("Anchored position when in Compact (in-game HUD) state. Typically a screen corner.")]
+        [SerializeField] private Vector2 compactPosition = new Vector2(-200f, 100f);
+
+        [Tooltip("Local scale when in Compact state. Default 1.")]
+        [SerializeField] private Vector3 compactScale = Vector3.one;
+
+        [Tooltip("Anchored position when in Expanded (level-up modal) state. Typically (0,0) for screen-center.")]
+        [SerializeField] private Vector2 expandedPosition = Vector2.zero;
+
+        [Tooltip("Local scale when in Expanded state. Larger so the cross dominates the screen during the modal.")]
+        [SerializeField] private Vector3 expandedScale = new Vector3(1.6f, 1.6f, 1f);
+
+        [Header("Diagnostics")]
+        [SerializeField] private bool verbose = false;
+
+        // ─── Public API ──────────────────────────────────────────────────
+
+        /// <summary>Current state of the cross — Compact (in-game HUD) or Expanded (modal).</summary>
+        public CrossState State { get; private set; } = CrossState.Compact;
+
+        /// <summary>True iff the cross is currently in slot-picker mode (waiting for the player to click an eligible slot).</summary>
+        public bool IsPicking { get; private set; }
+
+        /// <summary>
+        /// Fires when the player picks an eligible slot during slot-picker mode.
+        /// Argument is the axis index they chose.
+        /// </summary>
+        public event Action<int> OnSlotPicked;
+
+        /// <summary>
+        /// Fires when slot-picker mode is cancelled (programmatically — no
+        /// in-built ESC handler yet; the level-up modal can cancel via
+        /// <see cref="CancelSlotPicker"/>).
+        /// </summary>
+        public event Action OnSlotPickerCancelled;
+
+        /// <summary>
+        /// Set the cross's visual state (Compact ↔ Expanded). Currently
+        /// instant — DOTween animation lands in M8 step 5.
+        /// </summary>
+        public void SetState(CrossState state)
+        {
+            State = state;
+            ApplyState();
+        }
+
+        /// <summary>
+        /// Begin slot-picker mode. Highlights eligible (empty) slots of the
+        /// requested kind and waits for a click. Click → <see cref="OnSlotPicked"/>
+        /// fires + slot-picker mode ends.
+        /// </summary>
+        public void BeginSlotPicker(SlotKind kind)
+        {
+            if (IsPicking) CancelSlotPicker(); // defensive — clean previous picker
+
+            EnsureLoadoutBound();
+            _pickerKind = kind;
+            IsPicking = true;
+
+            UpdatePickerHighlights();
+
+            if (verbose) Debug.Log($"[LoadoutCrossPanel] BeginSlotPicker({kind}).");
+        }
+
+        /// <summary>
+        /// Cancel slot-picker mode without resolving (e.g., player pressed
+        /// Cancel on the level-up modal). Fires <see cref="OnSlotPickerCancelled"/>.
+        /// </summary>
+        public void CancelSlotPicker()
+        {
+            if (!IsPicking) return;
+            IsPicking = false;
+            ClearPickerHighlights();
+            OnSlotPickerCancelled?.Invoke();
+            if (verbose) Debug.Log("[LoadoutCrossPanel] CancelSlotPicker.");
+        }
+
+        // ─── Internal: lifecycle + binding ───────────────────────────────
+
+        private WeaponLoadoutRuntime _loadout;
+        private bool _bound;
+        private SlotKind _pickerKind;
+
+        private void Awake()
+        {
+            if (rect == null) rect = (RectTransform)transform;
+
+            // Stamp axis index on each slot so it knows which loadout axis to read.
+            for (int i = 0; i < weaponSlots.Length; i++)
+                if (weaponSlots[i] != null) weaponSlots[i].SetSlotIndex(i);
+            for (int i = 0; i < powerUpSlots.Length; i++)
+                if (powerUpSlots[i] != null) powerUpSlots[i].SetAxisIndex(i);
+
+            // Wire each slot's pointer events for slot-picker click handling.
+            // We use the slot's RectTransform position as the click target;
+            // the existing HoverableElement pointer click also fires (for
+            // tooltip lock toggling) — both are compatible because the
+            // HoverableElement's IsLockable governs whether the click
+            // toggles a lock. During picker mode we listen at this panel
+            // level via Update + raycasts (simpler than wiring per-slot
+            // delegates and tearing them down). See HandleSlotPickerInput.
+
+            ApplyState();
+        }
+
+        private void OnEnable()
+        {
+            MusicEventBus.OnEvent += HandleMusicEvent;
+        }
+
+        private void OnDisable()
+        {
+            MusicEventBus.OnEvent -= HandleMusicEvent;
+            UnbindLoadout();
+        }
+
+        private void HandleMusicEvent(MusicEvent type, object payload)
+        {
+            if (type == MusicEvent.RunStart) BindLoadout();
+        }
+
+        private void EnsureLoadoutBound()
+        {
+            if (_bound) return;
+            BindLoadout();
+        }
+
+        private void BindLoadout()
+        {
+            if (_loadout == null) _loadout = WeaponLoadoutRuntime.Instance;
+            if (_loadout == null)
+            {
+                Debug.LogError("[LoadoutCrossPanel] No WeaponLoadoutRuntime found.");
+                return;
+            }
+            if (_bound) return;
+
+            _loadout.OnWeaponAdded         += HandleWeaponAdded;
+            _loadout.OnWeaponLevelChanged  += HandleAxisChanged;
+            _loadout.OnWeaponRarityChanged += HandleAxisChanged;
+            _loadout.OnWeaponEvolved       += HandleAxisChanged;
+            _loadout.OnWeaponElementChanged+= HandleAxisChanged;
+            _loadout.OnPowerUpAdded        += HandlePowerUpAdded;
+            _loadout.OnPowerUpRemoved      += HandleAxisChanged;
+            _loadout.OnPowerUpLevelChanged += HandleAxisChanged;
+            _loadout.OnPowerUpRarityChanged+= HandleAxisChanged;
+            _loadout.OnLoadoutCleared      += HandleLoadoutCleared;
+            _bound = true;
+
+            // Initial paint — show whatever's already in the loadout.
+            RefreshAll();
+            if (verbose) Debug.Log("[LoadoutCrossPanel] Bound to WeaponLoadoutRuntime.");
+        }
+
+        private void UnbindLoadout()
+        {
+            if (!_bound || _loadout == null) return;
+            _loadout.OnWeaponAdded         -= HandleWeaponAdded;
+            _loadout.OnWeaponLevelChanged  -= HandleAxisChanged;
+            _loadout.OnWeaponRarityChanged -= HandleAxisChanged;
+            _loadout.OnWeaponEvolved       -= HandleAxisChanged;
+            _loadout.OnWeaponElementChanged-= HandleAxisChanged;
+            _loadout.OnPowerUpAdded        -= HandlePowerUpAdded;
+            _loadout.OnPowerUpRemoved      -= HandleAxisChanged;
+            _loadout.OnPowerUpLevelChanged -= HandleAxisChanged;
+            _loadout.OnPowerUpRarityChanged-= HandleAxisChanged;
+            _loadout.OnLoadoutCleared      -= HandleLoadoutCleared;
+            _bound = false;
+        }
+
+        // ─── Refresh dispatchers ─────────────────────────────────────────
+
+        private void HandleWeaponAdded(WeaponInstanceData added)
+        {
+            if (added != null) RefreshAxis(added.slotIndex);
+            UpdatePickerHighlights(); // axis just filled, highlights may change
+        }
+
+        private void HandlePowerUpAdded(PowerUpInstanceData added)
+        {
+            if (added != null) RefreshAxis(added.axisIndex);
+            UpdatePickerHighlights();
+        }
+
+        private void HandleAxisChanged(int axisIndex)
+        {
+            RefreshAxis(axisIndex);
+            UpdatePickerHighlights();
+        }
+
+        private void HandleLoadoutCleared()
+        {
+            RefreshAll();
+            UpdatePickerHighlights();
+        }
+
+        private void RefreshAxis(int axisIndex)
+        {
+            if (_loadout == null) return;
+            var axis = _loadout.GetAxis(axisIndex);
+            if (axis == null) return;
+
+            if (axisIndex < weaponSlots.Length && weaponSlots[axisIndex] != null)
+                weaponSlots[axisIndex].Refresh(axis.weapon);
+            if (axisIndex < powerUpSlots.Length && powerUpSlots[axisIndex] != null)
+                powerUpSlots[axisIndex].Refresh(axis.powerUp);
+        }
+
+        private void RefreshAll()
+        {
+            int n = weaponSlots.Length;
+            for (int i = 0; i < n; i++) RefreshAxis(i);
+        }
+
+        // ─── State (Compact / Expanded) ─────────────────────────────────
+
+        private void ApplyState()
+        {
+            if (rect == null) return;
+            switch (State)
+            {
+                case CrossState.Compact:
+                    rect.anchoredPosition = compactPosition;
+                    rect.localScale       = compactScale;
+                    break;
+                case CrossState.Expanded:
+                    rect.anchoredPosition = expandedPosition;
+                    rect.localScale       = expandedScale;
+                    break;
+            }
+        }
+
+        // ─── Slot-picker visuals + input ────────────────────────────────
+
+        private void UpdatePickerHighlights()
+        {
+            if (!IsPicking)
+            {
+                ClearPickerHighlights();
+                return;
+            }
+            if (_loadout == null) return;
+
+            int n = _loadout.AxisCount;
+            switch (_pickerKind)
+            {
+                case SlotKind.Weapon:
+                    for (int i = 0; i < n; i++)
+                    {
+                        bool eligible = !_loadout.GetAxis(i).HasWeapon;
+                        SetHighlight(weaponSlotHighlights, i, eligible);
+                        SetHighlight(powerUpSlotHighlights, i, false);
+                    }
+                    break;
+                case SlotKind.PowerUp:
+                    for (int i = 0; i < n; i++)
+                    {
+                        bool eligible = !_loadout.GetAxis(i).HasPowerUp;
+                        SetHighlight(weaponSlotHighlights, i, false);
+                        SetHighlight(powerUpSlotHighlights, i, eligible);
+                    }
+                    break;
+            }
+        }
+
+        private void ClearPickerHighlights()
+        {
+            for (int i = 0; i < (weaponSlotHighlights?.Length ?? 0); i++)
+                SetHighlight(weaponSlotHighlights, i, false);
+            for (int i = 0; i < (powerUpSlotHighlights?.Length ?? 0); i++)
+                SetHighlight(powerUpSlotHighlights, i, false);
+        }
+
+        private void SetHighlight(Image[] arr, int idx, bool on)
+        {
+            if (arr == null || idx < 0 || idx >= arr.Length) return;
+            var img = arr[idx];
+            if (img == null) return;
+            img.gameObject.SetActive(on);
+            if (on) img.color = slotPickerEligibleColor;
+        }
+
+        private void Update()
+        {
+            if (!IsPicking) return;
+            if (_loadout == null) return;
+            if (!Input.GetMouseButtonDown(0)) return;
+
+            // Pointer over which slot? For each eligible cell, hit-test the
+            // pointer position against the slot's RectTransform. First match
+            // wins. This avoids per-slot delegate wiring + lets us cleanly
+            // stop listening when picker mode ends.
+            int picked = HitTestPickerSlots();
+            if (picked < 0) return;
+
+            int axisIndex = picked;
+            IsPicking = false;
+            ClearPickerHighlights();
+            if (verbose) Debug.Log($"[LoadoutCrossPanel] Slot picked: axis {axisIndex} ({_pickerKind}).");
+            OnSlotPicked?.Invoke(axisIndex);
+        }
+
+        private int HitTestPickerSlots()
+        {
+            int n = _loadout.AxisCount;
+            Vector2 mouse = Input.mousePosition;
+            switch (_pickerKind)
+            {
+                case SlotKind.Weapon:
+                    for (int i = 0; i < n && i < weaponSlots.Length; i++)
+                    {
+                        if (_loadout.GetAxis(i).HasWeapon) continue; // not eligible
+                        if (weaponSlots[i] == null) continue;
+                        if (RectTransformUtility.RectangleContainsScreenPoint(
+                                (RectTransform)weaponSlots[i].transform, mouse, GetEventCamera()))
+                            return i;
+                    }
+                    break;
+
+                case SlotKind.PowerUp:
+                    for (int i = 0; i < n && i < powerUpSlots.Length; i++)
+                    {
+                        if (_loadout.GetAxis(i).HasPowerUp) continue;
+                        if (powerUpSlots[i] == null) continue;
+                        if (RectTransformUtility.RectangleContainsScreenPoint(
+                                (RectTransform)powerUpSlots[i].transform, mouse, GetEventCamera()))
+                            return i;
+                    }
+                    break;
+            }
+            return -1;
+        }
+
+        private Camera GetEventCamera()
+        {
+            // Screen Space Overlay canvases pass null to RectangleContainsScreenPoint;
+            // ScreenSpaceCamera / WorldSpace pass the canvas's worldCamera.
+            var canvas = GetComponentInParent<Canvas>();
+            if (canvas == null) return null;
+            return canvas.renderMode == RenderMode.ScreenSpaceOverlay ? null : canvas.worldCamera;
+        }
+    }
+}

--- a/Assets/_CyberPickle/Code/UI/HUD/LoadoutCrossPanel.cs.meta
+++ b/Assets/_CyberPickle/Code/UI/HUD/LoadoutCrossPanel.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 35dd875d7d9dce248bf7f840258f2fd7

--- a/Assets/_CyberPickle/Code/UI/HUD/PickedCardEntryUI.cs
+++ b/Assets/_CyberPickle/Code/UI/HUD/PickedCardEntryUI.cs
@@ -29,22 +29,32 @@ namespace CyberPickle.UI.HUD
         [Tooltip("TMP for the card's type tag (e.g., 'StatModifier', 'LevelUp', 'RarityUp'). Optional.")]
         [SerializeField] private TextMeshProUGUI typeTag;
 
-        private UpgradeCardSO _card;
+        private DraftedCard _drafted;
 
         // Picked-card details are static — the card was applied when picked,
         // its modifiers won't change. Tooltip just follows the mouse, no lock.
         public override bool IsLockable => false;
 
-        public void Bind(UpgradeCardSO card)
+        public void Bind(DraftedCard drafted)
         {
-            _card = card;
-            if (card == null) return;
+            _drafted = drafted;
+            if (!drafted.IsValid) return;
+
+            var card = drafted.source;
 
             if (nameText != null)
                 nameText.text = !string.IsNullOrEmpty(card.displayName) ? card.displayName : card.cardId;
 
+            // Rarity dot uses the ROLLED rarity (the actual one applied),
+            // not the asset's authored rarity. Same for the visual tint
+            // on power-up cards via element coupling — element overrides
+            // tint per chat 2026-05-11.
             if (rarityDot != null)
-                rarityDot.color = card.rarity.DisplayColor();
+            {
+                rarityDot.color = drafted.rolledElement != ElementId.None
+                    ? drafted.rolledElement.DisplayColor()
+                    : drafted.rolledRarity.DisplayColor();
+            }
 
             if (typeTag != null)
                 typeTag.text = card.cardType.ToString();
@@ -52,52 +62,86 @@ namespace CyberPickle.UI.HUD
 
         public override TooltipContent BuildContent()
         {
-            if (_card == null) return TooltipContent.Empty;
+            if (!_drafted.IsValid) return TooltipContent.Empty;
+            var card = _drafted.source;
 
             var sb = new StringBuilder(256);
-            string rarityHex = ColorUtility.ToHtmlStringRGB(_card.rarity.DisplayColor());
+            string rarityHex = ColorUtility.ToHtmlStringRGB(_drafted.rolledRarity.DisplayColor());
 
-            sb.AppendLine($"<color=#{rarityHex}>{_card.rarity.DisplayName()}</color>  •  {_card.cardType}");
-            if (!string.IsNullOrEmpty(_card.description))
+            sb.AppendLine($"<color=#{rarityHex}>{_drafted.rolledRarity.DisplayName()}</color>  •  {card.cardType}");
+            if (_drafted.rolledElement != ElementId.None)
+            {
+                string elementHex = ColorUtility.ToHtmlStringRGB(_drafted.rolledElement.DisplayColor());
+                sb.AppendLine($"<color=#{elementHex}>{_drafted.rolledElement.DisplayName()}</color>");
+            }
+            if (!string.IsNullOrEmpty(card.description))
             {
                 sb.AppendLine();
-                sb.AppendLine(_card.description);
+                sb.AppendLine(card.description);
             }
 
             // Detail by card type.
-            switch (_card.cardType)
+            switch (card.cardType)
             {
                 case CardType.StatModifier:
-                    AppendModifierList(sb, _card);
+                    AppendModifierList(sb, card);
                     break;
 
-                case CardType.LevelUp:
-                    if (_card.targetWeaponData != null)
+                case CardType.NewWeapon:
+                    if (card.targetWeaponData != null)
                     {
                         sb.AppendLine();
-                        sb.AppendLine($"<b>Targets:</b> {_card.targetWeaponData.displayName}");
-                        sb.AppendLine("Adds the weapon at L1 if not equipped, otherwise +1 level.");
+                        sb.AppendLine($"<b>Adds:</b> {card.targetWeaponData.displayName}");
+                        sb.AppendLine($"At rarity <b>{_drafted.rolledRarity}</b>.");
                     }
                     break;
 
-                case CardType.RarityUp:
-                    if (_card.targetWeaponData != null)
+                case CardType.LevelUpWeapon:
+                    if (card.targetWeaponData != null)
                     {
                         sb.AppendLine();
-                        sb.AppendLine($"<b>Targets:</b> {_card.targetWeaponData.displayName}");
-                        sb.AppendLine("Bumps the equipped weapon's rarity by +1 tier.");
+                        sb.AppendLine($"<b>Levels:</b> {card.targetWeaponData.displayName} +1");
                     }
                     break;
 
-                case CardType.PowerUp:
-                    sb.AppendLine();
-                    sb.AppendLine($"<b>Power-up:</b> <i>{_card.targetPowerUpId}</i>");
-                    sb.AppendLine("<size=80%><color=#aaaaaa>(M9 — power-up system not yet wired)</color></size>");
+                case CardType.RarityUpWeapon:
+                    if (card.targetWeaponData != null)
+                    {
+                        sb.AppendLine();
+                        sb.AppendLine($"<b>Rarity Up:</b> {card.targetWeaponData.displayName}");
+                    }
+                    break;
+
+                case CardType.NewPowerUp:
+                    if (card.targetPowerUpData != null)
+                    {
+                        sb.AppendLine();
+                        sb.AppendLine($"<b>Adds power-up:</b> {card.targetPowerUpData.displayName}");
+                        sb.AppendLine($"Stat: <b>{card.targetPowerUpData.affectedStat}</b> at <b>{_drafted.rolledRarity}</b>.");
+                        if (_drafted.rolledElement != ElementId.None)
+                            sb.AppendLine($"Confers <b>{_drafted.rolledElement}</b> to the weapon on the same axis.");
+                    }
+                    break;
+
+                case CardType.LevelUpPowerUp:
+                    if (card.targetPowerUpData != null)
+                    {
+                        sb.AppendLine();
+                        sb.AppendLine($"<b>Levels power-up:</b> {card.targetPowerUpData.displayName} +1");
+                    }
+                    break;
+
+                case CardType.RarityUpPowerUp:
+                    if (card.targetPowerUpData != null)
+                    {
+                        sb.AppendLine();
+                        sb.AppendLine($"<b>Rarity Up power-up:</b> {card.targetPowerUpData.displayName}");
+                    }
                     break;
 
                 case CardType.SkillUnlock:
                     sb.AppendLine();
-                    sb.AppendLine($"<b>Skill:</b> <i>{_card.targetSkillId}</i>");
+                    sb.AppendLine($"<b>Skill:</b> <i>{card.targetSkillId}</i>");
                     sb.AppendLine("<size=80%><color=#aaaaaa>(M11 — skill tree not yet wired)</color></size>");
                     break;
 
@@ -109,7 +153,7 @@ namespace CyberPickle.UI.HUD
 
             return new TooltipContent
             {
-                title = !string.IsNullOrEmpty(_card.displayName) ? _card.displayName : _card.cardId,
+                title = !string.IsNullOrEmpty(card.displayName) ? card.displayName : card.cardId,
                 body  = sb.ToString(),
             };
         }

--- a/Assets/_CyberPickle/Code/UI/HUD/PickedCardsPanel.cs
+++ b/Assets/_CyberPickle/Code/UI/HUD/PickedCardsPanel.cs
@@ -90,13 +90,13 @@ namespace CyberPickle.UI.HUD
             }
         }
 
-        private void HandleCardApplied(UpgradeCardSO card)
+        private void HandleCardApplied(DraftedCard card)
         {
-            if (card == null || entryPrefab == null || entryParent == null) return;
+            if (!card.IsValid || entryPrefab == null || entryParent == null) return;
 
             var entry = Instantiate(entryPrefab, entryParent);
             entry.Bind(card);
-            entry.gameObject.name = $"PickedCard_{card.cardId}";
+            entry.gameObject.name = $"PickedCard_{card.source.cardId}";
 
             if (latestFirst) entry.transform.SetAsFirstSibling();
             // else: default — appended last via instantiate

--- a/Assets/_CyberPickle/Code/UI/HUD/PowerUpSlotUI.cs
+++ b/Assets/_CyberPickle/Code/UI/HUD/PowerUpSlotUI.cs
@@ -1,0 +1,188 @@
+// File: Assets/_CyberPickle/Code/UI/HUD/PowerUpSlotUI.cs
+// Namespace: CyberPickle.UI.HUD
+//
+// One power-up slot display in the cross HUD. Mirrors WeaponSlotUI's
+// shape but renders PowerUpInstanceData (stat target + magnitude +
+// rolled element) instead of weapon data. Surfaces a hover tooltip via
+// the same HoverableElement base — keeps the M7.4 tooltip behavior the
+// user explicitly asked to preserve in the cross UI.
+//
+// The data sources read on every refresh / tooltip build:
+//   - WeaponLoadoutRuntime.GetPowerUp(axisIndex) for current rarity / element
+//   - PowerUpData fields (affectedStat + magnitudesByRarity) for the curve
+//   - WeaponLoadoutRuntime.GetSlot(axisIndex) for the coupled weapon name
+//     (so the tooltip can describe what this power-up is conferring its
+//     element to right now)
+//
+// Empty axes render with the rarity / element frames dimmed and a faint
+// placeholder icon — same convention as WeaponSlotUI so the cross layout
+// cell shape stays consistent regardless of fill state.
+
+using System.Text;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+using CyberPickle.Core;
+using CyberPickle.Gameplay.Weapons;
+using CyberPickle.Shop.Equipment.Data;
+using CyberPickle.UI.Tooltip;
+
+namespace CyberPickle.UI.HUD
+{
+    [DisallowMultipleComponent]
+    public class PowerUpSlotUI : HoverableElement
+    {
+        [Header("Display")]
+        [Tooltip("Headline label — e.g. 'Power Boost (Rare)'. '—' for empty. Required.")]
+        [SerializeField] private TextMeshProUGUI labelText;
+
+        [Tooltip("Compact stat readout — e.g. '+12% Power'. Optional.")]
+        [SerializeField] private TextMeshProUGUI statText;
+
+        [Tooltip("Image tinted by the power-up's rarity (frame, glow, fill — designer's call). Optional.")]
+        [SerializeField] private Image rarityFrame;
+
+        [Tooltip("Image tinted by the rolled element. Optional.")]
+        [SerializeField] private Image elementFrame;
+
+        [Tooltip("Image showing the power-up's sprite icon (from PowerUpData.equipmentIcon). Hidden when slot is empty. Optional.")]
+        [SerializeField] private Image iconImage;
+
+        // Axis index is set by the parent LoadoutCrossPanel based on array position.
+        private int _axisIndex;
+
+        public void SetAxisIndex(int idx) => _axisIndex = idx;
+
+        // ─── Refresh from current loadout state ───────────────────────────
+
+        public void Refresh(PowerUpInstanceData instance)
+        {
+            bool valid = instance != null && instance.IsValid;
+
+            if (labelText != null)
+            {
+                labelText.text = valid
+                    ? $"{instance.powerUpData.displayName} ({instance.rarity.DisplayName()})"
+                    : "—";
+            }
+
+            if (statText != null)
+            {
+                if (valid)
+                {
+                    float magnitude = instance.CurrentMagnitude;
+                    string sign = magnitude >= 0 ? "+" : string.Empty;
+                    statText.text = $"{sign}{magnitude * 100f:F0}% {instance.powerUpData.affectedStat}";
+                }
+                else
+                {
+                    statText.text = string.Empty;
+                }
+            }
+
+            if (rarityFrame != null)
+            {
+                rarityFrame.color = valid ? instance.rarity.DisplayColor() : new Color(0.3f, 0.3f, 0.3f, 1f);
+            }
+
+            if (elementFrame != null)
+            {
+                elementFrame.color = valid ? instance.element.DisplayColor() : new Color(0.3f, 0.3f, 0.3f, 1f);
+            }
+
+            if (iconImage != null)
+            {
+                Sprite sprite = (valid && instance.powerUpData != null) ? instance.powerUpData.equipmentIcon : null;
+                if (sprite != null)
+                {
+                    iconImage.sprite = sprite;
+                    iconImage.color = Color.white;
+                    iconImage.enabled = true;
+                }
+                else
+                {
+                    // Empty axis or no icon — faint placeholder so the cell shape stays consistent.
+                    iconImage.sprite = null;
+                    iconImage.color = new Color(1f, 1f, 1f, 0.10f);
+                    iconImage.enabled = true;
+                }
+            }
+        }
+
+        // ─── Tooltip content ──────────────────────────────────────────────
+
+        public override TooltipContent BuildContent()
+        {
+            var loadout = WeaponLoadoutRuntime.Instance;
+            var instance = loadout != null ? loadout.GetPowerUp(_axisIndex) : null;
+
+            if (instance == null || !instance.IsValid)
+            {
+                // Empty axis — describe what coupling could happen here.
+                var coupledWeapon = loadout != null ? loadout.GetSlot(_axisIndex) : null;
+                string body;
+                if (coupledWeapon != null && coupledWeapon.IsValid)
+                {
+                    body = $"<i>Empty — no power-up slotted.</i>\n\nA power-up here would confer its element to <b>{coupledWeapon.weaponData.displayName}</b> (currently neutral).";
+                }
+                else
+                {
+                    body = "<i>Empty — no power-up slotted.</i>\n\nA power-up here would still apply its global stat boost.";
+                }
+                return new TooltipContent { title = $"Axis {_axisIndex} — Power-up", body = body };
+            }
+
+            var sb = new StringBuilder(384);
+            string rarityHex = ColorUtility.ToHtmlStringRGB(instance.rarity.DisplayColor());
+            string elementHex = ColorUtility.ToHtmlStringRGB(instance.element.DisplayColor());
+
+            sb.AppendLine($"<color=#{rarityHex}>{instance.rarity.DisplayName()}</color>  •  L{instance.level}");
+            if (instance.element != ElementId.None)
+                sb.AppendLine($"<color=#{elementHex}>{instance.element.DisplayName()}</color>");
+            sb.AppendLine();
+
+            // Global stat boost.
+            float magnitude = instance.CurrentMagnitude;
+            sb.AppendLine("<b>Global Effect</b>");
+            sb.AppendLine($"<color=#88c8ff>{instance.powerUpData.affectedStat}</color>  +{magnitude * 100f:F0}%  <size=80%>(applies to all weapons)</size>");
+
+            // Element coupling.
+            if (instance.element != ElementId.None)
+            {
+                sb.AppendLine();
+                sb.AppendLine("<b>Element Coupling</b>");
+                var coupledWeapon = loadout.GetSlot(_axisIndex);
+                if (coupledWeapon != null && coupledWeapon.IsValid)
+                {
+                    sb.AppendLine($"Confers <color=#{elementHex}>{instance.element.DisplayName()}</color> to <b>{coupledWeapon.weaponData.displayName}</b> on this axis.");
+                }
+                else
+                {
+                    sb.AppendLine($"<size=80%><i>No weapon on this axis — element will apply once a weapon is slotted.</i></size>");
+                }
+            }
+
+            // Rarity progression preview (so the player sees the curve).
+            if (instance.powerUpData.magnitudesByRarity != null && instance.powerUpData.magnitudesByRarity.Length == 5)
+            {
+                sb.AppendLine();
+                sb.AppendLine("<b>Rarity Curve</b>");
+                var mags = instance.powerUpData.magnitudesByRarity;
+                int currentIdx = (int)instance.rarity;
+                for (int i = 0; i < 5; i++)
+                {
+                    string rarityName = ((Rarity)i).DisplayName();
+                    string highlight = (i == currentIdx) ? "<b>" : "<color=#888888>";
+                    string close     = (i == currentIdx) ? "</b>" : "</color>";
+                    sb.AppendLine($"  {highlight}{rarityName} +{mags[i] * 100f:F0}%{close}");
+                }
+            }
+
+            return new TooltipContent
+            {
+                title = instance.powerUpData.displayName,
+                body  = sb.ToString(),
+            };
+        }
+    }
+}

--- a/Assets/_CyberPickle/Code/UI/HUD/PowerUpSlotUI.cs.meta
+++ b/Assets/_CyberPickle/Code/UI/HUD/PowerUpSlotUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 458922bc0e7c35f4b8791dba10a681bc

--- a/Assets/_CyberPickle/Code/UI/Screens/LevelUp/CardSlot.cs
+++ b/Assets/_CyberPickle/Code/UI/Screens/LevelUp/CardSlot.cs
@@ -49,8 +49,15 @@ namespace CyberPickle.UI.Screens.LevelUp
         [Tooltip("TMP for the rarity badge ('COMMON', 'RARE', etc.). Optional.")]
         [SerializeField] private TextMeshProUGUI rarityText;
 
-        [Tooltip("TMP for the element badge ('FIRE', 'LIGHTNING', etc.) — only shown for power-up cards. Optional.")]
+        [Tooltip("TMP for the element badge ('FIRE', 'LIGHTNING', etc.) — only shown for power-up cards. Anchor this near the TOP of the card per the design (element 'faces the weapon ring' on the cross). Optional.")]
         [SerializeField] private TextMeshProUGUI elementText;
+
+        [Header("Stat Pips (bottom-of-card, M8 step 5)")]
+        [Tooltip("Parent RectTransform for the stat-magnitude pips. The card's visual concept (chat 2026-05-11) puts the element on top facing the weapon and the stat pips on the bottom facing the core — so anchor this container at the bottom of the card. Cleared and repopulated on each Bind. Optional — leave null to skip pip rendering.")]
+        [SerializeField] private RectTransform statPipsContainer;
+
+        [Tooltip("Prefab spawned once per rarity tier when populating the pip row. A small Image is sufficient — the script tints it by the rolled element / rarity. Hidden if statPipsContainer is null.")]
+        [SerializeField] private RectTransform statPipPrefab;
 
         [Header("Interaction")]
         [Tooltip("The pick button — usually the entire card area. Required.")]
@@ -148,6 +155,36 @@ namespace CyberPickle.UI.Screens.LevelUp
 
             if (banishButton != null)
                 banishButton.gameObject.SetActive(true);
+
+            // Stat pips — Common=1 ... Legendary=5. Tinted by the rolled
+            // element when present, else by rarity. Designer anchors the
+            // container at the card's bottom edge per the "modifiers face
+            // the core" visual concept.
+            PopulateStatPips(card);
+        }
+
+        private void PopulateStatPips(DraftedCard card)
+        {
+            if (statPipsContainer == null) return;
+
+            // Clear previous pips.
+            for (int i = statPipsContainer.childCount - 1; i >= 0; i--)
+                Destroy(statPipsContainer.GetChild(i).gameObject);
+
+            if (statPipPrefab == null) return;
+
+            int pipCount = (int)card.rolledRarity + 1; // Common=1 ... Legendary=5
+            Color tint = card.rolledElement != ElementId.None
+                ? card.rolledElement.DisplayColor()
+                : card.rolledRarity.DisplayColor();
+
+            for (int i = 0; i < pipCount; i++)
+            {
+                var pip = Instantiate(statPipPrefab, statPipsContainer);
+                pip.gameObject.SetActive(true);
+                var graphic = pip.GetComponent<Graphic>();
+                if (graphic != null) graphic.color = tint;
+            }
         }
 
         /// <summary>Disable interaction (e.g., during the pick-completion animation).</summary>

--- a/Assets/_CyberPickle/Code/UI/Screens/LevelUp/CardSlot.cs
+++ b/Assets/_CyberPickle/Code/UI/Screens/LevelUp/CardSlot.cs
@@ -1,10 +1,11 @@
 // File: Assets/_CyberPickle/Code/UI/Screens/LevelUp/CardSlot.cs
 // Namespace: CyberPickle.UI.Screens.LevelUp
 //
-// One card slot in the level-up choice screen. Binds an UpgradeCardSO to
-// the slot's visual elements (background tint, icon, name, description,
-// rarity badge), and surfaces hover + click as C# callbacks the parent
-// controller wires up.
+// One card slot in the level-up choice screen. Binds a DraftedCard
+// (the card SO + the values rolled at draft time — rarity, element)
+// to the slot's visual elements (background tint, icon, name,
+// description, rarity badge, element badge), and surfaces hover +
+// click as C# callbacks the parent controller wires up.
 //
 // Why a separate component (not just inline in LevelUpScreenController):
 // - Clean separation: controller owns flow, slot owns view
@@ -22,6 +23,7 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
+using CyberPickle.Core;
 using CyberPickle.Gameplay.Audio;
 using CyberPickle.Gameplay.Progression;
 
@@ -47,6 +49,9 @@ namespace CyberPickle.UI.Screens.LevelUp
         [Tooltip("TMP for the rarity badge ('COMMON', 'RARE', etc.). Optional.")]
         [SerializeField] private TextMeshProUGUI rarityText;
 
+        [Tooltip("TMP for the element badge ('FIRE', 'LIGHTNING', etc.) — only shown for power-up cards. Optional.")]
+        [SerializeField] private TextMeshProUGUI elementText;
+
         [Header("Interaction")]
         [Tooltip("The pick button — usually the entire card area. Required.")]
         [SerializeField] private Button pickButton;
@@ -64,7 +69,8 @@ namespace CyberPickle.UI.Screens.LevelUp
 
         // ─── Public state ─────────────────────────────────────────────────
 
-        public UpgradeCardSO Card { get; private set; }
+        /// <summary>The DraftedCard currently shown by this slot. Default if not bound.</summary>
+        public DraftedCard Card { get; private set; }
 
         // ─── Lifecycle ────────────────────────────────────────────────────
 
@@ -83,14 +89,16 @@ namespace CyberPickle.UI.Screens.LevelUp
         // ─── Public API ───────────────────────────────────────────────────
 
         /// <summary>
-        /// Bind a card to this slot. Updates all visuals. Pass null to clear
-        /// (used when the slot is recycled across level-ups).
+        /// Bind a drafted card to this slot. Updates all visuals. Pass an
+        /// invalid (default) DraftedCard to clear the slot (used when the
+        /// slot is recycled across level-ups or when the player has fewer
+        /// cards than slots).
         /// </summary>
-        public void Bind(UpgradeCardSO card)
+        public void Bind(DraftedCard card)
         {
             Card = card;
 
-            if (card == null)
+            if (!card.IsValid)
             {
                 gameObject.SetActive(false);
                 return;
@@ -98,26 +106,46 @@ namespace CyberPickle.UI.Screens.LevelUp
 
             gameObject.SetActive(true);
 
+            var so = card.source;
+            // For power-up cards, tint by element instead of card.tintColor.
+            // The element badge mirrors this — keeps the visual identity
+            // matched (per chat 2026-05-11 design: element on top of card).
             if (backgroundImage != null)
-                backgroundImage.color = card.tintColor;
+            {
+                backgroundImage.color = card.rolledElement != ElementId.None
+                    ? card.rolledElement.DisplayColor()
+                    : so.tintColor;
+            }
 
             if (iconImage != null)
             {
-                iconImage.sprite = card.icon;
-                iconImage.enabled = card.icon != null;
+                iconImage.sprite = so.icon;
+                iconImage.enabled = so.icon != null;
             }
 
             if (nameText != null)
-                nameText.text = card.displayName;
+                nameText.text = so.displayName;
 
             if (descriptionText != null)
-                descriptionText.text = card.description ?? string.Empty;
+                descriptionText.text = so.description ?? string.Empty;
 
             if (rarityText != null)
-                rarityText.text = card.rarity.ToString().ToUpperInvariant();
+                rarityText.text = card.rolledRarity.ToString().ToUpperInvariant();
 
-            // Hide banish button if not configured. Future: hide based on
-            // whether banishment is allowed for this run (token currency check).
+            if (elementText != null)
+            {
+                if (card.rolledElement != ElementId.None)
+                {
+                    elementText.text = card.rolledElement.DisplayName().ToUpperInvariant();
+                    elementText.color = card.rolledElement.DisplayColor();
+                    elementText.gameObject.SetActive(true);
+                }
+                else
+                {
+                    elementText.gameObject.SetActive(false);
+                }
+            }
+
             if (banishButton != null)
                 banishButton.gameObject.SetActive(true);
         }
@@ -133,10 +161,10 @@ namespace CyberPickle.UI.Screens.LevelUp
 
         public void OnPointerEnter(PointerEventData eventData)
         {
-            if (Card == null) return;
+            if (!Card.IsValid) return;
             // Bus event drives the hover-stinger preview (Stage 0 = log,
             // Stage 2 = Wwise event post). See GDD §3.11.4.
-            MusicEventBus.Fire(MusicEvent.CardHover, Card.cardId);
+            MusicEventBus.Fire(MusicEvent.CardHover, Card.source.cardId);
         }
 
         public void OnPointerExit(PointerEventData eventData)
@@ -148,13 +176,13 @@ namespace CyberPickle.UI.Screens.LevelUp
 
         private void HandlePickClicked()
         {
-            if (Card == null) return;
+            if (!Card.IsValid) return;
             OnPicked?.Invoke(this);
         }
 
         private void HandleBanishClicked()
         {
-            if (Card == null) return;
+            if (!Card.IsValid) return;
             OnBanished?.Invoke(this);
         }
     }

--- a/Assets/_CyberPickle/Code/UI/Screens/LevelUp/LevelUpScreenController.cs
+++ b/Assets/_CyberPickle/Code/UI/Screens/LevelUp/LevelUpScreenController.cs
@@ -3,51 +3,42 @@
 //
 // The level-up choice screen UI. Subscribes to LevelUpCoordinator's
 // OnCardsDrawn event, populates the slots, fades in. Click on a slot
-// reports back to the coordinator and fades out.
+// either commits the card immediately (StatModifier / LevelUp / RarityUp
+// cards) or hands off to the cross-panel slot-picker for cards that need
+// the player to pick an axis (NewWeapon / NewPowerUp).
+//
+// Skip and Reroll buttons:
+//   - Skip → coordinator.NotifyDraftSkipped() (adds +1 to bankedRerolls,
+//     resumes run with no card applied)
+//   - Reroll → coordinator.NotifyRerollRequested() (spends 1 banked
+//     reroll, redraws the same draft) — disabled when bankedRerolls == 0
 //
 // Critical detail: this UI runs while RunStateManager.CurrentPhase ==
 // LevelUpPaused, which sets Time.timeScale = 0. ALL animations and
 // timers MUST use unscaled time, or the UI will freeze the moment it
-// appears. Same defensive pattern we used for EquipmentHubManager fades
-// and the ResultsScreenController.
+// appears.
 //
-// What this is (Day 3, minimum viable):
-//   - 3 pre-authored CardSlot GameObjects in a CanvasGroup panel
+// What this is (M8 step 4 cut):
+//   - 3+ pre-authored CardSlot GameObjects in a CanvasGroup panel
 //   - Fade in / fade out via unscaled time
-//   - Click → coordinator
-//   - Banish click → coordinator
+//   - Click → coordinator (or → slot-picker if RequiresSlotSelection)
+//   - Skip + Reroll buttons
+//   - Optional Cancel button to back out of slot-picker mode
 //
-// What this is NOT (yet):
-//   - 3D model preview rigs per slot — Day 4
-//   - Hold-to-confirm picking — Day 5
-//   - Beat-aligned slow-mo (Time.timeScale = 0.05 instead of 0) — Day 5
-//   - Hover-stinger Wwise preview — handled at MusicEventBus listener
-//     level when Wwise integrates (M9, Stage 2 of audio rollout)
-//
-// Hierarchy convention (drop these in Game.unity under your Canvas):
-//
-//   [LevelUpScreenPanel]            ← CanvasGroup, alpha=0, !raycasts initially
-//     ├─ Background (full-screen dim)
-//     ├─ Title (TMP "LEVEL UP")
-//     ├─ Slot1 (CardSlot component)
-//     │   ├─ Background (Image)
-//     │   ├─ Icon (Image)
-//     │   ├─ Name (TMP)
-//     │   ├─ Description (TMP)
-//     │   ├─ Rarity (TMP)
-//     │   ├─ PickButton (Button on the whole card area)
-//     │   └─ BanishButton (Button, small X icon)
-//     ├─ Slot2 (CardSlot component, same layout)
-//     └─ Slot3 (CardSlot component, same layout)
-//
-// Drop LevelUpScreenController on [LevelUpScreenPanel]. Drag the 3
-// CardSlot components into the slots[] array. Wire panelGroup to the
-// CanvasGroup on the same GameObject.
+// What this is NOT (yet, M8 step 5 polish):
+//   - 3D model preview rigs per slot
+//   - Hold-to-confirm picking
+//   - Beat-aligned slow-mo (timeScale = 0.05)
+//   - Slot-picker fade animation
+//   - Cards-in-the-center-of-the-cross expanded layout
 
 using System.Collections;
 using System.Collections.Generic;
+using TMPro;
 using UnityEngine;
+using UnityEngine.UI;
 using CyberPickle.Gameplay.Progression;
+using CyberPickle.UI.HUD;
 
 namespace CyberPickle.UI.Screens.LevelUp
 {
@@ -58,55 +49,99 @@ namespace CyberPickle.UI.Screens.LevelUp
         [Tooltip("CanvasGroup driving the panel's visibility. Should start with alpha=0, interactable=false, blocksRaycasts=false.")]
         [SerializeField] private CanvasGroup panelGroup;
 
-        [Tooltip("Seconds to fade the panel in / out. Uses unscaled time so it animates while the game is paused (Time.timeScale=0 during LevelUpPaused).")]
+        [Tooltip("Seconds to fade the panel in / out. Uses unscaled time.")]
         [Min(0f)] [SerializeField] private float fadeDuration = 0.4f;
 
         [Header("Slots")]
-        [Tooltip("The card slots — typically 3, matching LevelUpCoordinator.cardsPerOffer. Each slot is a CardSlot MonoBehaviour authored in the scene.")]
+        [Tooltip("The card slots — typically 3, but can be up to 6 (Luck-driven). Slots beyond the drawn count are hidden via Bind(default).")]
         [SerializeField] private CardSlot[] slots = new CardSlot[3];
 
-        [Header("Coordinator")]
-        [Tooltip("The level-up coordinator this screen subscribes to. Auto-discovered if left empty at OnEnable.")]
+        [Header("Coordinator + Cross Panel")]
+        [Tooltip("Level-up coordinator this screen subscribes to. Auto-discovered at OnEnable if null.")]
         [SerializeField] private LevelUpCoordinator coordinator;
+
+        [Tooltip("LoadoutCrossPanel used as the slot-picker when a NewWeapon/NewPowerUp card is clicked. Auto-discovered at OnEnable if null.")]
+        [SerializeField] private LoadoutCrossPanel crossPanel;
+
+        [Header("Skip / Reroll")]
+        [Tooltip("Optional Skip button — invokes coordinator.NotifyDraftSkipped() on click (adds +1 to banked rerolls).")]
+        [SerializeField] private Button skipButton;
+
+        [Tooltip("Optional Reroll button — invokes coordinator.NotifyRerollRequested() on click (spends 1 banked reroll).")]
+        [SerializeField] private Button rerollButton;
+
+        [Tooltip("Optional TMP showing the current banked-reroll count, e.g. 'Reroll (×2)'.")]
+        [SerializeField] private TextMeshProUGUI rerollLabel;
+
+        [Tooltip("Optional Cancel button shown only during slot-picker mode — backs out so the player can pick a different card.")]
+        [SerializeField] private Button cancelSlotPickerButton;
+
+        [Tooltip("Optional TMP shown during slot-picker mode (e.g. 'Pick a slot →').")]
+        [SerializeField] private TextMeshProUGUI slotPickerHintLabel;
 
         [Header("Diagnostics")]
         [SerializeField] private bool verbose = true;
+
+        // ─── Internal state ───────────────────────────────────────────────
+
+        // The card the player has clicked but not yet committed (because
+        // it requires a slot-pick). null when no card is pending.
+        private DraftedCard? _pendingSlottableCard;
 
         // ─── Lifecycle ────────────────────────────────────────────────────
 
         private void Awake()
         {
-            // Hidden until OnCardsDrawn fires.
             SetPanelVisibility(0f, interactable: false);
+            SetSlotPickerHint(false);
         }
 
         private void OnEnable()
         {
-            if (coordinator == null)
-                coordinator = FindFirstObjectByType<LevelUpCoordinator>();
+            if (coordinator == null) coordinator = FindFirstObjectByType<LevelUpCoordinator>();
+            if (crossPanel == null)  crossPanel  = FindFirstObjectByType<LoadoutCrossPanel>();
 
             if (coordinator != null)
             {
-                coordinator.OnCardsDrawn += HandleCardsDrawn;
+                coordinator.OnCardsDrawn          += HandleCardsDrawn;
+                coordinator.OnBankedRerollsChanged += HandleBankedRerollsChanged;
+                HandleBankedRerollsChanged(coordinator.BankedRerolls); // initial paint
             }
             else
             {
-                Debug.LogWarning("[LevelUpScreenController] No LevelUpCoordinator found. Screen will never display cards.");
+                Debug.LogWarning("[LevelUpScreenController] No LevelUpCoordinator found.");
             }
 
-            // Wire each slot's pick + banish events to our local handlers.
+            if (crossPanel != null)
+            {
+                crossPanel.OnSlotPicked            += HandleSlotPicked;
+                crossPanel.OnSlotPickerCancelled   += HandleSlotPickerCancelled;
+            }
+
             for (int i = 0; i < slots.Length; i++)
             {
                 if (slots[i] == null) continue;
                 slots[i].OnPicked   += HandleSlotPicked;
                 slots[i].OnBanished += HandleSlotBanished;
             }
+
+            if (skipButton != null)               skipButton.onClick.AddListener(HandleSkipClicked);
+            if (rerollButton != null)             rerollButton.onClick.AddListener(HandleRerollClicked);
+            if (cancelSlotPickerButton != null)   cancelSlotPickerButton.onClick.AddListener(HandleCancelSlotPickerClicked);
         }
 
         private void OnDisable()
         {
             if (coordinator != null)
-                coordinator.OnCardsDrawn -= HandleCardsDrawn;
+            {
+                coordinator.OnCardsDrawn          -= HandleCardsDrawn;
+                coordinator.OnBankedRerollsChanged -= HandleBankedRerollsChanged;
+            }
+            if (crossPanel != null)
+            {
+                crossPanel.OnSlotPicked          -= HandleSlotPicked;
+                crossPanel.OnSlotPickerCancelled -= HandleSlotPickerCancelled;
+            }
 
             for (int i = 0; i < slots.Length; i++)
             {
@@ -114,6 +149,10 @@ namespace CyberPickle.UI.Screens.LevelUp
                 slots[i].OnPicked   -= HandleSlotPicked;
                 slots[i].OnBanished -= HandleSlotBanished;
             }
+
+            if (skipButton != null)             skipButton.onClick.RemoveListener(HandleSkipClicked);
+            if (rerollButton != null)           rerollButton.onClick.RemoveListener(HandleRerollClicked);
+            if (cancelSlotPickerButton != null) cancelSlotPickerButton.onClick.RemoveListener(HandleCancelSlotPickerClicked);
         }
 
         // ─── Coordinator → UI ─────────────────────────────────────────────
@@ -122,9 +161,6 @@ namespace CyberPickle.UI.Screens.LevelUp
         {
             if (verbose) Debug.Log($"[LevelUpScreen] Showing {cards.Count} cards.");
 
-            // Bind each slot. If the coordinator drew fewer cards than we
-            // have slots (small pool, lots banished), unused slots hide
-            // themselves via Bind(default DraftedCard).
             for (int i = 0; i < slots.Length; i++)
             {
                 if (slots[i] == null) continue;
@@ -133,43 +169,133 @@ namespace CyberPickle.UI.Screens.LevelUp
                 slots[i].SetInteractable(true);
             }
 
+            _pendingSlottableCard = null;
+            SetSlotPickerHint(false);
+
             StopAllCoroutines();
             StartCoroutine(FadeIn());
         }
 
+        private void HandleBankedRerollsChanged(int newCount)
+        {
+            if (rerollButton != null) rerollButton.interactable = newCount > 0;
+            if (rerollLabel != null)  rerollLabel.text = newCount > 0 ? $"Reroll (×{newCount})" : "Reroll";
+        }
+
         // ─── Slot interactions → Coordinator ──────────────────────────────
 
+        // CardSlot.OnPicked — player clicked a card on the level-up panel.
         private void HandleSlotPicked(CardSlot slot)
         {
             if (slot == null || !slot.Card.IsValid || coordinator == null) return;
 
-            if (verbose) Debug.Log($"[LevelUpScreen] Picked '{slot.Card.source.cardId}'.");
+            var card = slot.Card;
+            if (verbose) Debug.Log($"[LevelUpScreen] Picked '{card.source.cardId}'.");
 
-            // Disable all slots immediately so a fast double-click can't
-            // pick two cards before the fade-out completes.
             for (int i = 0; i < slots.Length; i++)
                 if (slots[i] != null) slots[i].SetInteractable(false);
 
-            // Apply via the coordinator. For cards requiring slot-pick
-            // (NewWeapon / NewPowerUp), this currently auto-picks the
-            // first empty axis (axisIndex=-1). The cross-UI slot-picker
-            // flow lands in M8 step 4 — it'll route through a new
-            // coordinator.RequestCommit() → coordinator.NotifySlotPicked()
-            // sequence so the player chooses the axis explicitly.
-            coordinator.NotifyCardPicked(slot.Card);
+            // Cards that need an axis pick → enter slot-picker mode.
+            // Other cards → commit immediately.
+            if (card.RequiresSlotSelection && crossPanel != null)
+            {
+                _pendingSlottableCard = card;
+                var kind = card.source.cardType == CardType.NewWeapon
+                    ? LoadoutCrossPanel.SlotKind.Weapon
+                    : LoadoutCrossPanel.SlotKind.PowerUp;
+                crossPanel.BeginSlotPicker(kind);
+                SetSlotPickerHint(true, kind);
+                if (verbose) Debug.Log($"[LevelUpScreen] Awaiting slot pick ({kind}).");
+                // Keep the level-up panel visible (dimmed could be added later)
+                // so the player still sees what they're committing to. Cancel
+                // button lets them back out without committing.
+                return;
+            }
 
-            StopAllCoroutines();
-            StartCoroutine(FadeOut());
+            CommitPick(card, axisIndex: -1);
+        }
+
+        // LoadoutCrossPanel.OnSlotPicked — player clicked an eligible slot
+        // during slot-picker mode.
+        private void HandleSlotPicked(int axisIndex)
+        {
+            if (_pendingSlottableCard == null) return;
+            var card = _pendingSlottableCard.Value;
+            _pendingSlottableCard = null;
+            SetSlotPickerHint(false);
+            if (verbose) Debug.Log($"[LevelUpScreen] Slot picked: axis {axisIndex}. Committing '{card.source.cardId}'.");
+            CommitPick(card, axisIndex);
+        }
+
+        private void HandleSlotPickerCancelled()
+        {
+            if (_pendingSlottableCard == null) return;
+            // Slot picker was cancelled — re-enable the cards so the player
+            // can pick a different one.
+            _pendingSlottableCard = null;
+            SetSlotPickerHint(false);
+            for (int i = 0; i < slots.Length; i++)
+                if (slots[i] != null) slots[i].SetInteractable(true);
+            if (verbose) Debug.Log("[LevelUpScreen] Slot picker cancelled — re-enabling cards.");
         }
 
         private void HandleSlotBanished(CardSlot slot)
         {
             if (slot == null || !slot.Card.IsValid || coordinator == null) return;
-
             if (verbose) Debug.Log($"[LevelUpScreen] Banished '{slot.Card.source.cardId}'.");
-
             coordinator.NotifyCardBanished(slot.Card);
             slot.Bind(default);
+        }
+
+        private void HandleSkipClicked()
+        {
+            if (coordinator == null) return;
+            if (verbose) Debug.Log("[LevelUpScreen] Skip clicked.");
+            // If we're mid-slot-pick, cancel that first.
+            if (_pendingSlottableCard != null) HandleCancelSlotPickerClicked();
+            coordinator.NotifyDraftSkipped();
+            StopAllCoroutines();
+            StartCoroutine(FadeOut());
+        }
+
+        private void HandleRerollClicked()
+        {
+            if (coordinator == null) return;
+            if (coordinator.BankedRerolls <= 0) return;
+            if (verbose) Debug.Log("[LevelUpScreen] Reroll clicked.");
+            // Same: cancel any pending slot-pick before re-rolling.
+            if (_pendingSlottableCard != null) HandleCancelSlotPickerClicked();
+            coordinator.NotifyRerollRequested(); // OnCardsDrawn fires → HandleCardsDrawn rebinds
+        }
+
+        private void HandleCancelSlotPickerClicked()
+        {
+            if (crossPanel != null && crossPanel.IsPicking) crossPanel.CancelSlotPicker();
+            // CancelSlotPicker fires OnSlotPickerCancelled which re-enables cards.
+        }
+
+        private void CommitPick(DraftedCard card, int axisIndex)
+        {
+            coordinator.NotifyCardPicked(card, axisIndex);
+            StopAllCoroutines();
+            StartCoroutine(FadeOut());
+        }
+
+        // ─── Helpers ─────────────────────────────────────────────────────
+
+        private void SetSlotPickerHint(bool show, LoadoutCrossPanel.SlotKind kind = default)
+        {
+            if (slotPickerHintLabel != null)
+            {
+                slotPickerHintLabel.gameObject.SetActive(show);
+                if (show)
+                {
+                    string what = kind == LoadoutCrossPanel.SlotKind.Weapon ? "weapon" : "power-up";
+                    slotPickerHintLabel.text = $"Pick an empty {what} slot →";
+                }
+            }
+            if (cancelSlotPickerButton != null)
+                cancelSlotPickerButton.gameObject.SetActive(show);
         }
 
         // ─── Fades (unscaled time) ────────────────────────────────────────
@@ -177,7 +303,6 @@ namespace CyberPickle.UI.Screens.LevelUp
         private IEnumerator FadeIn()
         {
             if (panelGroup == null) yield break;
-
             panelGroup.interactable   = true;
             panelGroup.blocksRaycasts = true;
 
@@ -194,7 +319,6 @@ namespace CyberPickle.UI.Screens.LevelUp
         private IEnumerator FadeOut()
         {
             if (panelGroup == null) yield break;
-
             float elapsed = 0f;
             while (elapsed < fadeDuration)
             {
@@ -202,7 +326,6 @@ namespace CyberPickle.UI.Screens.LevelUp
                 panelGroup.alpha = Mathf.Clamp01(1f - elapsed / fadeDuration);
                 yield return null;
             }
-
             panelGroup.alpha = 0f;
             panelGroup.interactable   = false;
             panelGroup.blocksRaycasts = false;

--- a/Assets/_CyberPickle/Code/UI/Screens/LevelUp/LevelUpScreenController.cs
+++ b/Assets/_CyberPickle/Code/UI/Screens/LevelUp/LevelUpScreenController.cs
@@ -118,17 +118,17 @@ namespace CyberPickle.UI.Screens.LevelUp
 
         // ─── Coordinator → UI ─────────────────────────────────────────────
 
-        private void HandleCardsDrawn(IReadOnlyList<UpgradeCardSO> cards)
+        private void HandleCardsDrawn(IReadOnlyList<DraftedCard> cards)
         {
             if (verbose) Debug.Log($"[LevelUpScreen] Showing {cards.Count} cards.");
 
             // Bind each slot. If the coordinator drew fewer cards than we
             // have slots (small pool, lots banished), unused slots hide
-            // themselves via Bind(null).
+            // themselves via Bind(default DraftedCard).
             for (int i = 0; i < slots.Length; i++)
             {
                 if (slots[i] == null) continue;
-                UpgradeCardSO card = i < cards.Count ? cards[i] : null;
+                DraftedCard card = i < cards.Count ? cards[i] : default;
                 slots[i].Bind(card);
                 slots[i].SetInteractable(true);
             }
@@ -141,16 +141,21 @@ namespace CyberPickle.UI.Screens.LevelUp
 
         private void HandleSlotPicked(CardSlot slot)
         {
-            if (slot == null || slot.Card == null || coordinator == null) return;
+            if (slot == null || !slot.Card.IsValid || coordinator == null) return;
 
-            if (verbose) Debug.Log($"[LevelUpScreen] Picked '{slot.Card.cardId}'.");
+            if (verbose) Debug.Log($"[LevelUpScreen] Picked '{slot.Card.source.cardId}'.");
 
             // Disable all slots immediately so a fast double-click can't
             // pick two cards before the fade-out completes.
             for (int i = 0; i < slots.Length; i++)
                 if (slots[i] != null) slots[i].SetInteractable(false);
 
-            // Apply via the coordinator (which transitions back to Running).
+            // Apply via the coordinator. For cards requiring slot-pick
+            // (NewWeapon / NewPowerUp), this currently auto-picks the
+            // first empty axis (axisIndex=-1). The cross-UI slot-picker
+            // flow lands in M8 step 4 — it'll route through a new
+            // coordinator.RequestCommit() → coordinator.NotifySlotPicked()
+            // sequence so the player chooses the axis explicitly.
             coordinator.NotifyCardPicked(slot.Card);
 
             StopAllCoroutines();
@@ -159,15 +164,12 @@ namespace CyberPickle.UI.Screens.LevelUp
 
         private void HandleSlotBanished(CardSlot slot)
         {
-            if (slot == null || slot.Card == null || coordinator == null) return;
+            if (slot == null || !slot.Card.IsValid || coordinator == null) return;
 
-            if (verbose) Debug.Log($"[LevelUpScreen] Banished '{slot.Card.cardId}'.");
+            if (verbose) Debug.Log($"[LevelUpScreen] Banished '{slot.Card.source.cardId}'.");
 
-            // Banishment doesn't end the level-up — the player still has
-            // to pick from the remaining cards. Just clear the banished
-            // slot so the player visually understands it's gone.
             coordinator.NotifyCardBanished(slot.Card);
-            slot.Bind(null);
+            slot.Bind(default);
         }
 
         // ─── Fades (unscaled time) ────────────────────────────────────────

--- a/Assets/_CyberPickle/Code/UI/Screens/LevelUp/LevelUpScreenController.cs
+++ b/Assets/_CyberPickle/Code/UI/Screens/LevelUp/LevelUpScreenController.cs
@@ -37,6 +37,7 @@ using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
+using CyberPickle.Core;
 using CyberPickle.Gameplay.Progression;
 using CyberPickle.UI.HUD;
 
@@ -172,6 +173,11 @@ namespace CyberPickle.UI.Screens.LevelUp
             _pendingSlottableCard = null;
             SetSlotPickerHint(false);
 
+            // Expand the cross — its center area becomes the visual stage
+            // for these cards. The cross's Compact ↔ Expanded tween (DOTween,
+            // unscaled time) animates while the game is paused.
+            if (crossPanel != null) crossPanel.SetState(LoadoutCrossPanel.CrossState.Expanded);
+
             StopAllCoroutines();
             StartCoroutine(FadeIn());
         }
@@ -254,6 +260,8 @@ namespace CyberPickle.UI.Screens.LevelUp
             // If we're mid-slot-pick, cancel that first.
             if (_pendingSlottableCard != null) HandleCancelSlotPickerClicked();
             coordinator.NotifyDraftSkipped();
+            // Skip resumes the run with no card applied — collapse the cross.
+            if (crossPanel != null) crossPanel.SetState(LoadoutCrossPanel.CrossState.Compact);
             StopAllCoroutines();
             StartCoroutine(FadeOut());
         }
@@ -276,9 +284,46 @@ namespace CyberPickle.UI.Screens.LevelUp
 
         private void CommitPick(DraftedCard card, int axisIndex)
         {
+            // Trigger the modifier-pip "fly into the core" animation BEFORE
+            // applying the card. The pip visual is element-tinted (matches
+            // the rolled element on the card) and spawns from the picked
+            // card slot's position.
+            if (crossPanel != null)
+            {
+                Vector2 fromScreenPos = GetClickedCardScreenPos(card);
+                Color elementColor = card.rolledElement != ElementId.None
+                    ? card.rolledElement.DisplayColor()
+                    : new Color(0.85f, 0.85f, 0.95f, 1f); // neutral chrome for non-element cards
+                crossPanel.PlayCommitAnimation(fromScreenPos, elementColor, pipCount: 5);
+            }
+
             coordinator.NotifyCardPicked(card, axisIndex);
+
+            // Collapse the cross + fade the panel as the run resumes.
+            if (crossPanel != null) crossPanel.SetState(LoadoutCrossPanel.CrossState.Compact);
             StopAllCoroutines();
             StartCoroutine(FadeOut());
+        }
+
+        /// <summary>
+        /// Find the screen-space position of the slot that's currently
+        /// showing the picked card, so the commit animation can spawn its
+        /// pips from there. Falls back to screen center if the slot can't
+        /// be matched (defensive — e.g., picked via debug command).
+        /// </summary>
+        private Vector2 GetClickedCardScreenPos(DraftedCard card)
+        {
+            for (int i = 0; i < slots.Length; i++)
+            {
+                if (slots[i] == null) continue;
+                if (!slots[i].Card.IsValid) continue;
+                if (slots[i].Card.source == card.source && slots[i].Card.rolledRarity == card.rolledRarity)
+                {
+                    var rt = (RectTransform)slots[i].transform;
+                    return RectTransformUtility.WorldToScreenPoint(null, rt.position);
+                }
+            }
+            return new Vector2(Screen.width * 0.5f, Screen.height * 0.5f);
         }
 
         // ─── Helpers ─────────────────────────────────────────────────────

--- a/Assets/_CyberPickle/Data/PowerUp/PowerUp 1.asset
+++ b/Assets/_CyberPickle/Data/PowerUp/PowerUp 1.asset
@@ -12,9 +12,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 60c4bada8b422b54bbfdd7a4003062ca, type: 3}
   m_Name: PowerUp 1
   m_EditorClassIdentifier: 
-  equipmentId: powerup_1
-  displayName: Power
-  description: 
+  equipmentId: powerup_power_boost
+  displayName: Power Boost
+  description: Boosts global Power. Element couples to the axis weapon's musical
+    mode.
   slotType: 2
   equipmentIcon: {fileID: 21300000, guid: 08b3fdf1413418d4cbc81ba07d51dd44, type: 3}
   equipmentPrefab: {fileID: 0}
@@ -24,23 +25,12 @@ MonoBehaviour:
   requiredPlayerLevel: 1
   requiredAchievements: []
   maxUpgradeLevel: 5
-  effectType: 0
-  baseDuration: 0
-  baseCooldown: 0
-  isPassive: 1
-  affectedStat: Speed
-  baseStatBoost: 10
-  isPercentageBased: 1
-  compatibleWeaponTypes: 00000000
-  synergisticWeaponIds:
-  - handweapon_lasergun
-  affectedWeaponProperties:
-  - Speed
-  baseWeaponEnhancementMultiplier: 1.2
-  baseEffectDescription: 
-  maxLevelEffectDescription: 
-  activeEffectPrefab: {fileID: 0}
-  activationSound: {fileID: 0}
-  effectStrengthUpgradeMultiplier: 1.2
-  durationUpgradeMultiplier: 1.15
-  cooldownReductionMultiplier: 0.9
+  affectedStat: 3
+  magnitudesByRarity:
+  - 0.1
+  - 0.15
+  - 0.22
+  - 0.32
+  - 0.45
+  slotEffectPrefab: {fileID: 0}
+  slotSound: {fileID: 0}

--- a/Assets/_CyberPickle/Data/PowerUp/PowerUp 2.asset
+++ b/Assets/_CyberPickle/Data/PowerUp/PowerUp 2.asset
@@ -12,9 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 60c4bada8b422b54bbfdd7a4003062ca, type: 3}
   m_Name: PowerUp 2
   m_EditorClassIdentifier: 
-  equipmentId: powerup_2
-  displayName: 
-  description: 
+  equipmentId: powerup_quick_reflexes
+  displayName: Quick Reflexes
+  description: Boosts global Dexterity. Music tempo (BPM) rises with this stat.
   slotType: 2
   equipmentIcon: {fileID: 21300000, guid: 08b3fdf1413418d4cbc81ba07d51dd44, type: 3}
   equipmentPrefab: {fileID: 0}
@@ -24,21 +24,12 @@ MonoBehaviour:
   requiredPlayerLevel: 1
   requiredAchievements: []
   maxUpgradeLevel: 5
-  effectType: 0
-  baseDuration: 0
-  baseCooldown: 0
-  isPassive: 1
-  affectedStat: Power
-  baseStatBoost: 10
-  isPercentageBased: 1
-  compatibleWeaponTypes: 
-  synergisticWeaponIds: []
-  affectedWeaponProperties: []
-  baseWeaponEnhancementMultiplier: 1.2
-  baseEffectDescription: 
-  maxLevelEffectDescription: 
-  activeEffectPrefab: {fileID: 0}
-  activationSound: {fileID: 0}
-  effectStrengthUpgradeMultiplier: 1.2
-  durationUpgradeMultiplier: 1.15
-  cooldownReductionMultiplier: 0.9
+  affectedStat: 9
+  magnitudesByRarity:
+  - 0.05
+  - 0.08
+  - 0.12
+  - 0.18
+  - 0.25
+  slotEffectPrefab: {fileID: 0}
+  slotSound: {fileID: 0}

--- a/Assets/_CyberPickle/Data/PowerUp/PowerUp 3.asset
+++ b/Assets/_CyberPickle/Data/PowerUp/PowerUp 3.asset
@@ -12,9 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 60c4bada8b422b54bbfdd7a4003062ca, type: 3}
   m_Name: PowerUp 3
   m_EditorClassIdentifier: 
-  equipmentId: powerup_3
-  displayName: 
-  description: 
+  equipmentId: powerup_critical_edge
+  displayName: Critical Edge
+  description: Boosts global Crit Chance. Crits trigger the music's mega-crit roll.
   slotType: 2
   equipmentIcon: {fileID: 21300000, guid: 08b3fdf1413418d4cbc81ba07d51dd44, type: 3}
   equipmentPrefab: {fileID: 0}
@@ -24,21 +24,12 @@ MonoBehaviour:
   requiredPlayerLevel: 1
   requiredAchievements: []
   maxUpgradeLevel: 5
-  effectType: 0
-  baseDuration: 0
-  baseCooldown: 0
-  isPassive: 1
-  affectedStat: Power
-  baseStatBoost: 10
-  isPercentageBased: 1
-  compatibleWeaponTypes: 
-  synergisticWeaponIds: []
-  affectedWeaponProperties: []
-  baseWeaponEnhancementMultiplier: 1.2
-  baseEffectDescription: 
-  maxLevelEffectDescription: 
-  activeEffectPrefab: {fileID: 0}
-  activationSound: {fileID: 0}
-  effectStrengthUpgradeMultiplier: 1.2
-  durationUpgradeMultiplier: 1.15
-  cooldownReductionMultiplier: 0.9
+  affectedStat: 4
+  magnitudesByRarity:
+  - 0.03
+  - 0.05
+  - 0.08
+  - 0.12
+  - 0.18
+  slotEffectPrefab: {fileID: 0}
+  slotSound: {fileID: 0}

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_LevelUpPowerUp_PowerBoost.asset
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_LevelUpPowerUp_PowerBoost.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eed9819a0a1f2914ba11fbb5034bb9dc, type: 3}
+  m_Name: Card_LevelUpPowerUp_PowerBoost
+  m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.Gameplay.Progression.UpgradeCardSO
+  cardId: level_up_powerup_power_boost
+  displayName: 'Power Boost: Level Up'
+  description: Levels Power Boost +1 (level reserved for future scaling).
+  icon: {fileID: 0}
+  tintColor: {r: 1, g: 0.85, b: 0.4, a: 1}
+  rarity: 0
+  cardType: 7
+  targetWeaponData: {fileID: 0}
+  targetPowerUpData: {fileID: 11400000, guid: 170f2367677308f4596b207e09ecf949, type: 2}
+  targetSkillId: 
+  modifiers: []
+  previewPrefab: {fileID: 0}
+  hoverStingerEventId: 
+  elementTags: []
+  prerequisiteCardIds: []

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_LevelUpPowerUp_PowerBoost.asset.meta
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_LevelUpPowerUp_PowerBoost.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 176abefdce06bcd40a994d1f578029bd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_LevelUpWeapon_Weapon1.asset
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_LevelUpWeapon_Weapon1.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eed9819a0a1f2914ba11fbb5034bb9dc, type: 3}
+  m_Name: Card_LevelUpWeapon_Weapon1
+  m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.Gameplay.Progression.UpgradeCardSO
+  cardId: level_up_weapon_1
+  displayName: 'Weapon 1: Level Up'
+  description: Adds another shot pattern cell to Weapon 1 (more bullets per second).
+  icon: {fileID: 0}
+  tintColor: {r: 1, g: 0.85, b: 0.4, a: 1}
+  rarity: 0
+  cardType: 1
+  targetWeaponData: {fileID: 11400000, guid: 337d641fff86e97429d92d6710915768, type: 2}
+  targetPowerUpData: {fileID: 0}
+  targetSkillId: 
+  modifiers: []
+  previewPrefab: {fileID: 0}
+  hoverStingerEventId: 
+  elementTags: []
+  prerequisiteCardIds: []

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_LevelUpWeapon_Weapon1.asset.meta
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_LevelUpWeapon_Weapon1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 60f8812b1f87bc8479a1e28fe8aad917
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_NewPowerUp_CriticalEdge.asset
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_NewPowerUp_CriticalEdge.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eed9819a0a1f2914ba11fbb5034bb9dc, type: 3}
+  m_Name: Card_NewPowerUp_CriticalEdge
+  m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.Gameplay.Progression.UpgradeCardSO
+  cardId: new_powerup_critical_edge
+  displayName: Critical Edge
+  description: Gain +Crit Chance. Crits trigger the music's mega-crit roll.
+  icon: {fileID: 0}
+  tintColor: {r: 0.8, g: 0.8, b: 0.95, a: 1}
+  rarity: 1
+  cardType: 2
+  targetWeaponData: {fileID: 0}
+  targetPowerUpData: {fileID: 11400000, guid: 7d9139795d69c4442b8442fcb97ffcac, type: 2}
+  targetSkillId: 
+  modifiers: []
+  previewPrefab: {fileID: 0}
+  hoverStingerEventId: 
+  elementTags: []
+  prerequisiteCardIds: []

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_NewPowerUp_CriticalEdge.asset.meta
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_NewPowerUp_CriticalEdge.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cd5d2334d1b7a594491cc4c0fd7f85f2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_NewPowerUp_PowerBoost.asset
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_NewPowerUp_PowerBoost.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eed9819a0a1f2914ba11fbb5034bb9dc, type: 3}
+  m_Name: Card_NewPowerUp_PowerBoost
+  m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.Gameplay.Progression.UpgradeCardSO
+  cardId: new_powerup_power_boost
+  displayName: Power Boost
+  description: Gain +Power. Element rolls per draft and confers to the slotted axis's
+    weapon.
+  icon: {fileID: 0}
+  tintColor: {r: 0.8, g: 0.8, b: 0.95, a: 1}
+  rarity: 0
+  cardType: 2
+  targetWeaponData: {fileID: 0}
+  targetPowerUpData: {fileID: 11400000, guid: 170f2367677308f4596b207e09ecf949, type: 2}
+  targetSkillId: 
+  modifiers: []
+  previewPrefab: {fileID: 0}
+  hoverStingerEventId: 
+  elementTags: []
+  prerequisiteCardIds: []

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_NewPowerUp_PowerBoost.asset.meta
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_NewPowerUp_PowerBoost.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 69e2fc089d1647844b8ce12961c43ead
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_NewPowerUp_QuickReflexes.asset
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_NewPowerUp_QuickReflexes.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eed9819a0a1f2914ba11fbb5034bb9dc, type: 3}
+  m_Name: Card_NewPowerUp_QuickReflexes
+  m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.Gameplay.Progression.UpgradeCardSO
+  cardId: new_powerup_quick_reflexes
+  displayName: Quick Reflexes
+  description: Gain +Dexterity. Higher Dex drives faster pattern playback (BPM up).
+  icon: {fileID: 0}
+  tintColor: {r: 0.8, g: 0.8, b: 0.95, a: 1}
+  rarity: 0
+  cardType: 2
+  targetWeaponData: {fileID: 0}
+  targetPowerUpData: {fileID: 11400000, guid: de28818bf90e34844a8b01452e4660fd, type: 2}
+  targetSkillId: 
+  modifiers: []
+  previewPrefab: {fileID: 0}
+  hoverStingerEventId: 
+  elementTags: []
+  prerequisiteCardIds: []

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_NewPowerUp_QuickReflexes.asset.meta
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_NewPowerUp_QuickReflexes.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7c8ffcb92348c5447a172e1be652fbc5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_NewWeapon_Weapon1.asset
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_NewWeapon_Weapon1.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eed9819a0a1f2914ba11fbb5034bb9dc, type: 3}
+  m_Name: Card_NewWeapon_Weapon1
+  m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.Gameplay.Progression.UpgradeCardSO
+  cardId: new_weapon_1
+  displayName: 'New Weapon: Weapon 1'
+  description: Equip Weapon 1 on a chosen axis.
+  icon: {fileID: 0}
+  tintColor: {r: 0.85, g: 0.85, b: 0.95, a: 1}
+  rarity: 0
+  cardType: 6
+  targetWeaponData: {fileID: 11400000, guid: 337d641fff86e97429d92d6710915768, type: 2}
+  targetPowerUpData: {fileID: 0}
+  targetSkillId: 
+  modifiers: []
+  previewPrefab: {fileID: 0}
+  hoverStingerEventId: 
+  elementTags: []
+  prerequisiteCardIds: []

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_NewWeapon_Weapon1.asset.meta
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_NewWeapon_Weapon1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d1dc7de003af1cf4e928bae553dd7b78
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_NewWeapon_Weapon2.asset
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_NewWeapon_Weapon2.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eed9819a0a1f2914ba11fbb5034bb9dc, type: 3}
+  m_Name: Card_NewWeapon_Weapon2
+  m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.Gameplay.Progression.UpgradeCardSO
+  cardId: new_weapon_2
+  displayName: 'New Weapon: Weapon 2'
+  description: Equip Weapon 2 on a chosen axis.
+  icon: {fileID: 0}
+  tintColor: {r: 0.5, g: 0.95, b: 0.55, a: 1}
+  rarity: 1
+  cardType: 6
+  targetWeaponData: {fileID: 11400000, guid: aa7e9ddd2b8d5a741bb7158f0ff0a735, type: 2}
+  targetPowerUpData: {fileID: 0}
+  targetSkillId: 
+  modifiers: []
+  previewPrefab: {fileID: 0}
+  hoverStingerEventId: 
+  elementTags: []
+  prerequisiteCardIds: []

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_NewWeapon_Weapon2.asset.meta
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_NewWeapon_Weapon2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9f4a7ffc4a8f19841b46a94e5989f4a6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_NewWeapon_Weapon3.asset
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_NewWeapon_Weapon3.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eed9819a0a1f2914ba11fbb5034bb9dc, type: 3}
+  m_Name: Card_NewWeapon_Weapon3
+  m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.Gameplay.Progression.UpgradeCardSO
+  cardId: new_weapon_3
+  displayName: 'New Weapon: Weapon 3'
+  description: Equip Weapon 3 on a chosen axis.
+  icon: {fileID: 0}
+  tintColor: {r: 0.5, g: 0.65, b: 1, a: 1}
+  rarity: 2
+  cardType: 6
+  targetWeaponData: {fileID: 11400000, guid: 5868cd0a3c54dd24d95ddbd595b4d7a8, type: 2}
+  targetPowerUpData: {fileID: 0}
+  targetSkillId: 
+  modifiers: []
+  previewPrefab: {fileID: 0}
+  hoverStingerEventId: 
+  elementTags: []
+  prerequisiteCardIds: []

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_NewWeapon_Weapon3.asset.meta
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_NewWeapon_Weapon3.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 358ecbf6ad9f85040bd09dba1e762840
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_RarityUpPowerUp_PowerBoost.asset
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_RarityUpPowerUp_PowerBoost.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eed9819a0a1f2914ba11fbb5034bb9dc, type: 3}
+  m_Name: Card_RarityUpPowerUp_PowerBoost
+  m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.Gameplay.Progression.UpgradeCardSO
+  cardId: rarity_up_powerup_power_boost
+  displayName: 'Power Boost: Rarity Up'
+  description: Bumps Power Boost rarity +1 tier (larger stat magnitude).
+  icon: {fileID: 0}
+  tintColor: {r: 1, g: 0.6, b: 0.4, a: 1}
+  rarity: 1
+  cardType: 8
+  targetWeaponData: {fileID: 0}
+  targetPowerUpData: {fileID: 11400000, guid: 170f2367677308f4596b207e09ecf949, type: 2}
+  targetSkillId: 
+  modifiers: []
+  previewPrefab: {fileID: 0}
+  hoverStingerEventId: 
+  elementTags: []
+  prerequisiteCardIds: []

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_RarityUpPowerUp_PowerBoost.asset.meta
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_RarityUpPowerUp_PowerBoost.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e52289ec4faa8284db18bd617e30a5ce
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_RarityUpWeapon_Weapon1.asset
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_RarityUpWeapon_Weapon1.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eed9819a0a1f2914ba11fbb5034bb9dc, type: 3}
+  m_Name: Card_RarityUpWeapon_Weapon1
+  m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.Gameplay.Progression.UpgradeCardSO
+  cardId: rarity_up_weapon_1
+  displayName: 'Weapon 1: Rarity Up'
+  description: Bumps Weapon 1's rarity by +1 tier (more damage per shot).
+  icon: {fileID: 0}
+  tintColor: {r: 1, g: 0.6, b: 0.4, a: 1}
+  rarity: 1
+  cardType: 3
+  targetWeaponData: {fileID: 11400000, guid: 337d641fff86e97429d92d6710915768, type: 2}
+  targetPowerUpData: {fileID: 0}
+  targetSkillId: 
+  modifiers: []
+  previewPrefab: {fileID: 0}
+  hoverStingerEventId: 
+  elementTags: []
+  prerequisiteCardIds: []

--- a/Assets/_CyberPickle/Data/UI/Cards/Card_RarityUpWeapon_Weapon1.asset.meta
+++ b/Assets/_CyberPickle/Data/UI/Cards/Card_RarityUpWeapon_Weapon1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f87ed30c458d7f64bb7b2888b5791e25
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_CyberPickle/Data/UI/Cards/Pool_Default.asset
+++ b/Assets/_CyberPickle/Data/UI/Cards/Pool_Default.asset
@@ -18,9 +18,28 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 11d4249a2b1179b4b8074be32670f0f0, type: 2}
   - {fileID: 11400000, guid: c7a117e3d3be5b3429e348293e0b2578, type: 2}
   - {fileID: 11400000, guid: 71467b13c49d9d0448f123f516e8a8f8, type: 2}
+  - {fileID: 11400000, guid: d1dc7de003af1cf4e928bae553dd7b78, type: 2}
+  - {fileID: 11400000, guid: 9f4a7ffc4a8f19841b46a94e5989f4a6, type: 2}
+  - {fileID: 11400000, guid: 358ecbf6ad9f85040bd09dba1e762840, type: 2}
+  - {fileID: 11400000, guid: 60f8812b1f87bc8479a1e28fe8aad917, type: 2}
+  - {fileID: 11400000, guid: f87ed30c458d7f64bb7b2888b5791e25, type: 2}
+  - {fileID: 11400000, guid: 69e2fc089d1647844b8ce12961c43ead, type: 2}
+  - {fileID: 11400000, guid: 7c8ffcb92348c5447a172e1be652fbc5, type: 2}
+  - {fileID: 11400000, guid: cd5d2334d1b7a594491cc4c0fd7f85f2, type: 2}
+  - {fileID: 11400000, guid: 176abefdce06bcd40a994d1f578029bd, type: 2}
+  - {fileID: 11400000, guid: e52289ec4faa8284db18bd617e30a5ce, type: 2}
   weightCommon: 60
   weightUncommon: 25
   weightRare: 10
   weightEpic: 4
   weightLegendary: 1
+  weightTypeStatModifier: 30
+  weightTypeLevelUpWeapon: 50
+  weightTypeNewPowerUp: 25
+  weightTypeRarityUpWeapon: 15
+  weightTypeSkillUnlock: 10
+  weightTypeCosmetic: 0
+  weightTypeNewWeapon: 30
+  weightTypeLevelUpPowerUp: 30
+  weightTypeRarityUpPowerUp: 12
   luckShiftPerHundred: 0.5

--- a/Assets/_CyberPickle/Prefabs/HUD/CommitPip.prefab
+++ b/Assets/_CyberPickle/Prefabs/HUD/CommitPip.prefab
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &9031331528011952391
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 430963127454635442}
+  - component: {fileID: 855110144077563472}
+  - component: {fileID: 6953743826666337421}
+  m_Layer: 0
+  m_Name: CommitPip
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &430963127454635442
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9031331528011952391}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 10, y: 10}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &855110144077563472
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9031331528011952391}
+  m_CullTransparentMesh: 1
+--- !u!114 &6953743826666337421
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9031331528011952391}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Assets/_CyberPickle/Prefabs/HUD/CommitPip.prefab.meta
+++ b/Assets/_CyberPickle/Prefabs/HUD/CommitPip.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a90fac6d714a4cd46965530012629d75
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_CyberPickle/Prefabs/HUD/StatPip.prefab
+++ b/Assets/_CyberPickle/Prefabs/HUD/StatPip.prefab
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8933188782520103852
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7437840053478547460}
+  - component: {fileID: 4104636736414457340}
+  - component: {fileID: 7907177865641586476}
+  m_Layer: 0
+  m_Name: StatPip
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7437840053478547460
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8933188782520103852}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 8, y: 8}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4104636736414457340
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8933188782520103852}
+  m_CullTransparentMesh: 1
+--- !u!114 &7907177865641586476
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8933188782520103852}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Assets/_CyberPickle/Prefabs/HUD/StatPip.prefab.meta
+++ b/Assets/_CyberPickle/Prefabs/HUD/StatPip.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b6607ef08ba531f4ca84385302c9356e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_CyberPickle/Resources/ElementVfxLibrary.asset
+++ b/Assets/_CyberPickle/Resources/ElementVfxLibrary.asset
@@ -1,0 +1,50 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8a2db73577ddc2b48bbfaac73acdf385, type: 3}
+  m_Name: ElementVfxLibrary
+  m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.Gameplay.Weapons.ElementVfxLibrary
+  entries:
+  - element: 0
+    flashPrefab: {fileID: 0}
+    projectilePrefab: {fileID: 0}
+    hitPrefab: {fileID: 0}
+  - element: 1
+    flashPrefab: {fileID: 0}
+    projectilePrefab: {fileID: 0}
+    hitPrefab: {fileID: 0}
+  - element: 2
+    flashPrefab: {fileID: 0}
+    projectilePrefab: {fileID: 0}
+    hitPrefab: {fileID: 0}
+  - element: 3
+    flashPrefab: {fileID: 0}
+    projectilePrefab: {fileID: 0}
+    hitPrefab: {fileID: 0}
+  - element: 4
+    flashPrefab: {fileID: 0}
+    projectilePrefab: {fileID: 0}
+    hitPrefab: {fileID: 0}
+  - element: 5
+    flashPrefab: {fileID: 1569979447995748, guid: de79adfa69af17a4a8392603753976a1,
+      type: 3}
+    projectilePrefab: {fileID: 1569979447995748, guid: de79adfa69af17a4a8392603753976a1,
+      type: 3}
+    hitPrefab: {fileID: 1569979447995748, guid: de79adfa69af17a4a8392603753976a1,
+      type: 3}
+  - element: 6
+    flashPrefab: {fileID: 0}
+    projectilePrefab: {fileID: 0}
+    hitPrefab: {fileID: 0}
+  - element: 7
+    flashPrefab: {fileID: 0}
+    projectilePrefab: {fileID: 0}
+    hitPrefab: {fileID: 0}

--- a/Assets/_CyberPickle/Resources/ElementVfxLibrary.asset.meta
+++ b/Assets/_CyberPickle/Resources/ElementVfxLibrary.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fb5be9db03d5dee43824f437e73278cf
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_CyberPickle/Scenes/Game/Game.unity
+++ b/Assets/_CyberPickle/Scenes/Game/Game.unity
@@ -274,6 +274,41 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &84723667
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 84723668}
+  m_Layer: 0
+  m_Name: CardSpawnContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &84723668
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 84723667}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1854075781}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 500, y: 200}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &136492084
 GameObject:
   m_ObjectHideFlags: 0
@@ -1124,7 +1159,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.Gameplay.Progression.LevelUpCoordinator
   pool: {fileID: 11400000, guid: 3f4b49ee1ac46c7468979805f7b80ac4, type: 2}
   playerStats: {fileID: 0}
-  cardsPerOffer: 3
+  cardsPerOfferFloor: 3
+  bankedRerollsCap: 3
   verbose: 1
 --- !u!4 &300398874
 Transform:
@@ -2373,6 +2409,68 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dfb6bc953e172c94f9e518ed293dfd32, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.Gameplay.RunState.RunStatsTracker
+--- !u!1 &496452541
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 496452542}
+  - component: {fileID: 496452543}
+  m_Layer: 0
+  m_Name: StatPipsContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &496452542
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 496452541}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1940658946}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: 6}
+  m_SizeDelta: {x: 0, y: 14}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!114 &496452543
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 496452541}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.HorizontalLayoutGroup
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 4
+  m_Spacing: 4
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 0
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
 --- !u!1 &521169463
 GameObject:
   m_ObjectHideFlags: 0
@@ -2592,6 +2690,7 @@ RectTransform:
   - {fileID: 1450390653}
   - {fileID: 1467550218}
   - {fileID: 2023258640}
+  - {fileID: 796058609}
   m_Father: {fileID: 1230510421}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -2616,6 +2715,10 @@ MonoBehaviour:
   nameText: {fileID: 2067407914}
   descriptionText: {fileID: 1086944830}
   rarityText: {fileID: 1450390654}
+  elementText: {fileID: 0}
+  statPipsContainer: {fileID: 796058609}
+  statPipPrefab: {fileID: 7437840053478547460, guid: b6607ef08ba531f4ca84385302c9356e,
+    type: 3}
   pickButton: {fileID: 1467550219}
   banishButton: {fileID: 2023258641}
 --- !u!225 &551597032
@@ -2845,6 +2948,127 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 586063461}
+  m_CullTransparentMesh: 1
+--- !u!1 &595602646
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 595602647}
+  - component: {fileID: 595602650}
+  - component: {fileID: 595602649}
+  - component: {fileID: 595602648}
+  m_Layer: 0
+  m_Name: SkipButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &595602647
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 595602646}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1711192555}
+  m_Father: {fileID: 1282590689}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -180, y: 0}
+  m_SizeDelta: {x: 120, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &595602648
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 595602646}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 595602649}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &595602649
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 595602646}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.15, g: 0.18, b: 0.25, a: 0.95}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &595602650
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 595602646}
   m_CullTransparentMesh: 1
 --- !u!1 &596394233
 GameObject:
@@ -3438,6 +3662,280 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 722683949}
   m_CullTransparentMesh: 1
+--- !u!1 &763908788
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 763908789}
+  - component: {fileID: 763908791}
+  - component: {fileID: 763908790}
+  m_Layer: 0
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &763908789
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 763908788}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1829887553}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &763908790
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 763908788}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Reroll
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 18
+  m_fontSizeBase: 18
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &763908791
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 763908788}
+  m_CullTransparentMesh: 1
+--- !u!1 &790489221
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 790489222}
+  - component: {fileID: 790489224}
+  - component: {fileID: 790489223}
+  m_Layer: 0
+  m_Name: SlotPickerHint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &790489222
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 790489221}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1230510421}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 130}
+  m_SizeDelta: {x: 600, y: 40}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!114 &790489223
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 790489221}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "Pick an empty slot \u2192"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 0.32, g: 0.85, b: 0.99, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: 0
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 22
+  m_fontSizeBase: 22
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &790489224
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 790489221}
+  m_CullTransparentMesh: 1
 --- !u!1 &790648795
 GameObject:
   m_ObjectHideFlags: 0
@@ -3575,6 +4073,68 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 790648795}
   m_CullTransparentMesh: 1
+--- !u!1 &796058608
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 796058609}
+  - component: {fileID: 796058610}
+  m_Layer: 0
+  m_Name: StatPipsContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &796058609
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 796058608}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 551597030}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: 6}
+  m_SizeDelta: {x: 0, y: 14}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!114 &796058610
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 796058608}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.HorizontalLayoutGroup
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 4
+  m_Spacing: 4
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 0
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
 --- !u!1 &872272449
 GameObject:
   m_ObjectHideFlags: 0
@@ -4855,6 +5415,68 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1044611198}
   m_CullTransparentMesh: 1
+--- !u!1 &1062419997
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1062419998}
+  - component: {fileID: 1062419999}
+  m_Layer: 0
+  m_Name: StatPipsContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1062419998
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1062419997}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1071791098}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: 6}
+  m_SizeDelta: {x: 0, y: 14}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!114 &1062419999
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1062419997}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.HorizontalLayoutGroup
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 4
+  m_Spacing: 4
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 0
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
 --- !u!1 &1071791097
 GameObject:
   m_ObjectHideFlags: 0
@@ -4892,6 +5514,7 @@ RectTransform:
   - {fileID: 1027135006}
   - {fileID: 207336860}
   - {fileID: 173131958}
+  - {fileID: 1062419998}
   m_Father: {fileID: 1230510421}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -4916,6 +5539,10 @@ MonoBehaviour:
   nameText: {fileID: 477250079}
   descriptionText: {fileID: 409085382}
   rarityText: {fileID: 1027135007}
+  elementText: {fileID: 0}
+  statPipsContainer: {fileID: 1062419998}
+  statPipPrefab: {fileID: 7437840053478547460, guid: b6607ef08ba531f4ca84385302c9356e,
+    type: 3}
   pickButton: {fileID: 207336861}
   banishButton: {fileID: 173131959}
 --- !u!225 &1071791100
@@ -5161,6 +5788,8 @@ RectTransform:
   - {fileID: 1940658946}
   - {fileID: 1071791098}
   - {fileID: 551597030}
+  - {fileID: 1282590689}
+  - {fileID: 790489222}
   m_Father: {fileID: 1803396267}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -5187,6 +5816,12 @@ MonoBehaviour:
   - {fileID: 1071791099}
   - {fileID: 551597031}
   coordinator: {fileID: 0}
+  crossPanel: {fileID: 1854075784}
+  skipButton: {fileID: 595602648}
+  rerollButton: {fileID: 1829887554}
+  rerollLabel: {fileID: 763908790}
+  cancelSlotPickerButton: {fileID: 1807065524}
+  slotPickerHintLabel: {fileID: 790489223}
   verbose: 1
 --- !u!114 &1230510423
 MonoBehaviour:
@@ -5588,6 +6223,44 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1259588361}
   m_CullTransparentMesh: 1
+--- !u!1 &1282590688
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1282590689}
+  m_Layer: 0
+  m_Name: Buttons
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1282590689
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1282590688}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 595602647}
+  - {fileID: 1829887553}
+  - {fileID: 1807065523}
+  m_Father: {fileID: 1230510421}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 60}
+  m_SizeDelta: {x: 800, y: 60}
+  m_Pivot: {x: 0.5, y: 0}
 --- !u!1 &1305791333
 GameObject:
   m_ObjectHideFlags: 0
@@ -6865,6 +7538,143 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1685923797}
   m_CullTransparentMesh: 1
+--- !u!1 &1711192554
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1711192555}
+  - component: {fileID: 1711192557}
+  - component: {fileID: 1711192556}
+  m_Layer: 0
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1711192555
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1711192554}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 595602647}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1711192556
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1711192554}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Skip
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 18
+  m_fontSizeBase: 18
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1711192557
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1711192554}
+  m_CullTransparentMesh: 1
 --- !u!1001 &1765357655
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7166,6 +7976,248 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &1807065522
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1807065523}
+  - component: {fileID: 1807065526}
+  - component: {fileID: 1807065525}
+  - component: {fileID: 1807065524}
+  m_Layer: 0
+  m_Name: CancelButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1807065523
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1807065522}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1901012230}
+  m_Father: {fileID: 1282590689}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 180, y: 0}
+  m_SizeDelta: {x: 140, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1807065524
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1807065522}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1807065525}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1807065525
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1807065522}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.15, g: 0.18, b: 0.25, a: 0.95}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1807065526
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1807065522}
+  m_CullTransparentMesh: 1
+--- !u!1 &1829887552
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1829887553}
+  - component: {fileID: 1829887556}
+  - component: {fileID: 1829887555}
+  - component: {fileID: 1829887554}
+  m_Layer: 0
+  m_Name: RerollButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1829887553
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1829887552}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 763908789}
+  m_Father: {fileID: 1282590689}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 160, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1829887554
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1829887552}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1829887555}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1829887555
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1829887552}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.15, g: 0.18, b: 0.25, a: 0.95}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1829887556
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1829887552}
+  m_CullTransparentMesh: 1
 --- !u!1 &1839047031
 GameObject:
   m_ObjectHideFlags: 0
@@ -7314,8 +8366,9 @@ GameObject:
   - component: {fileID: 1854075781}
   - component: {fileID: 1854075783}
   - component: {fileID: 1854075782}
+  - component: {fileID: 1854075784}
   m_Layer: 0
-  m_Name: '[WeaponSlotsPanel]'
+  m_Name: '[LoadoutCrossPanel]'
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -7337,13 +8390,18 @@ RectTransform:
   - {fileID: 1765357656}
   - {fileID: 620483736}
   - {fileID: 530800147}
+  - {fileID: 5046353410795562271}
+  - {fileID: 8629829940318579523}
+  - {fileID: 2783522140089132056}
+  - {fileID: 7796576470580452198}
+  - {fileID: 84723668}
   m_Father: {fileID: 404248936}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0}
-  m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: 0, y: 16}
-  m_SizeDelta: {x: 1200, y: 60}
-  m_Pivot: {x: 0.5, y: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -360, y: -210}
+  m_SizeDelta: {x: 700, y: 600}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1854075782
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -7351,7 +8409,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1854075780}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c1fe78e4fec86a144b42d91585a73f73, type: 3}
   m_Name: 
@@ -7388,6 +8446,181 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!114 &1854075784
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1854075780}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 35dd875d7d9dce248bf7f840258f2fd7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.UI.HUD.LoadoutCrossPanel
+  weaponSlots:
+  - {fileID: 2065869102}
+  - {fileID: 1765357657}
+  - {fileID: 620483737}
+  - {fileID: 530800148}
+  powerUpSlots:
+  - {fileID: 5653184908642545305}
+  - {fileID: 9205158162414969029}
+  - {fileID: 8565889613478920423}
+  - {fileID: 7796576470580452199}
+  weaponSlotHighlights: []
+  powerUpSlotHighlights: []
+  slotPickerEligibleColor: {r: 0.4, g: 0.95, b: 1, a: 0.6}
+  rect: {fileID: 0}
+  compactPosition: {x: -360, y: -210}
+  compactScale: {x: 0.5, y: 0.5, z: 1}
+  expandedPosition: {x: 0, y: 0}
+  expandedScale: {x: 1, y: 1, z: 1}
+  cardSpawnContainer: {fileID: 84723668}
+  stateTweenDuration: 0.45
+  stateTweenEase: 27
+  verbose: 1
+  commitPipPrefab: {fileID: 430963127454635442, guid: a90fac6d714a4cd46965530012629d75,
+    type: 3}
+  commitPipDuration: 0.7
+  commitPipEase: 5
+--- !u!1 &1901012229
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1901012230}
+  - component: {fileID: 1901012232}
+  - component: {fileID: 1901012231}
+  m_Layer: 0
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1901012230
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1901012229}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1807065523}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1901012231
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1901012229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Cancel pick
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 18
+  m_fontSizeBase: 18
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1901012232
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1901012229}
+  m_CullTransparentMesh: 1
 --- !u!1 &1940658945
 GameObject:
   m_ObjectHideFlags: 0
@@ -7425,6 +8658,7 @@ RectTransform:
   - {fileID: 884267094}
   - {fileID: 1627487758}
   - {fileID: 14474310}
+  - {fileID: 496452542}
   m_Father: {fileID: 1230510421}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -7449,6 +8683,10 @@ MonoBehaviour:
   nameText: {fileID: 197486199}
   descriptionText: {fileID: 1839047033}
   rarityText: {fileID: 884267095}
+  elementText: {fileID: 0}
+  statPipsContainer: {fileID: 496452542}
+  statPipPrefab: {fileID: 7437840053478547460, guid: b6607ef08ba531f4ca84385302c9356e,
+    type: 3}
   pickButton: {fileID: 1627487759}
   banishButton: {fileID: 14474311}
 --- !u!225 &1940658948
@@ -8408,7 +9646,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: New Text
+  m_text: TimerTexts
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -8435,7 +9673,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 44.75
+  m_fontSize: 41
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -9118,6 +10356,2090 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2136795664}
   m_CullTransparentMesh: 1
+--- !u!222 &368324677035590448
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7228025569570312417}
+  m_CullTransparentMesh: 1
+--- !u!222 &389790677039279849
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1154667503615248654}
+  m_CullTransparentMesh: 1
+--- !u!222 &437472856005219678
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 738066628160136753}
+  m_CullTransparentMesh: 1
+--- !u!222 &495510105796820298
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6007800608388791921}
+  m_CullTransparentMesh: 1
+--- !u!1 &738066628160136753
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7567970242760045767}
+  - component: {fileID: 437472856005219678}
+  - component: {fileID: 4707420952442580982}
+  m_Layer: 0
+  m_Name: DPS
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &861985901478770987
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 896087007851156091}
+  - component: {fileID: 2204653753264152268}
+  - component: {fileID: 8125434223549457332}
+  m_Layer: 0
+  m_Name: Icon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &896087007851156091
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 861985901478770987}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7796576470580452198}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 4, y: 0}
+  m_SizeDelta: {x: 48, y: 48}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &1046783930022911037
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6422684909970535656}
+  m_CullTransparentMesh: 1
+--- !u!224 &1065396803106903933
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3744408570819379062}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2783522140089132056}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -4, y: -4}
+  m_SizeDelta: {x: 10, y: 10}
+  m_Pivot: {x: 1, y: 1}
+--- !u!1 &1154667503615248654
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1702318897558610526}
+  - component: {fileID: 389790677039279849}
+  - component: {fileID: 7724525510064231313}
+  m_Layer: 0
+  m_Name: Icon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1168191876132020397
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6583274779330259306}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 0.65, g: 0.85, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 12
+  m_fontSizeBase: 12
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 4096
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &1283090308043363860
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8283954458591069410}
+  - component: {fileID: 2153397203596797307}
+  - component: {fileID: 6531431173564391379}
+  m_Layer: 0
+  m_Name: DPS
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1605839116365251041
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5653184908642545304}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.1, g: 0.12, b: 0.18, a: 0.85}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!224 &1702318897558610526
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1154667503615248654}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8629829940318579523}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 4, y: 0}
+  m_SizeDelta: {x: 48, y: 48}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!114 &2100856366338156184
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6422684909970535656}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\u2014"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 4096
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &2153397203596797307
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1283090308043363860}
+  m_CullTransparentMesh: 1
+--- !u!222 &2204653753264152268
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 861985901478770987}
+  m_CullTransparentMesh: 1
+--- !u!222 &2228399122209207061
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9205158162414969028}
+  m_CullTransparentMesh: 1
+--- !u!1 &2435705026456864594
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2762031687140289538}
+  - component: {fileID: 3793086027180777653}
+  - component: {fileID: 6555103802014735821}
+  m_Layer: 0
+  m_Name: Icon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!222 &2647504417008083524
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8294164490411248273}
+  m_CullTransparentMesh: 1
+--- !u!224 &2762031687140289538
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2435705026456864594}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5046353410795562271}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 4, y: 0}
+  m_SizeDelta: {x: 48, y: 48}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!224 &2783522140089132056
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3376878023570796447}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.85, y: 0.85, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5115390148210650373}
+  - {fileID: 3965959493576889886}
+  - {fileID: 4063525522472893340}
+  - {fileID: 1065396803106903933}
+  m_Father: {fileID: 1854075781}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 280, y: 56}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2846970955565371325
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9205158162414969028}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.1, g: 0.12, b: 0.18, a: 0.85}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &3232274591354422067
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8747329268476968968}
+  m_CullTransparentMesh: 1
+--- !u!114 &3237193751889766596
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7560025136434969268}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\u2014"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 4096
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &3239420283717317623
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3744408570819379062}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3376878023570796447
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2783522140089132056}
+  - component: {fileID: 5732663453887822926}
+  - component: {fileID: 8565889613478920422}
+  - component: {fileID: 8565889613478920423}
+  m_Layer: 0
+  m_Name: PowerUpSlot_2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!222 &3397880272575184201
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5653184908642545304}
+  m_CullTransparentMesh: 1
+--- !u!1 &3744408570819379062
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1065396803106903933}
+  - component: {fileID: 7370517664501660749}
+  - component: {fileID: 3239420283717317623}
+  m_Layer: 0
+  m_Name: ElementFrame
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!222 &3793086027180777653
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2435705026456864594}
+  m_CullTransparentMesh: 1
+--- !u!224 &3965959493576889886
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4145780020770534895}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2783522140089132056}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 26, y: -1}
+  m_SizeDelta: {x: -68, y: -2}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &3971192967513053409
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8294164490411248273}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\u2014"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 4096
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &3975280973495825174
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7103463013140099117}
+  m_CullTransparentMesh: 1
+--- !u!222 &4024344592339294978
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4320443646223247469}
+  m_CullTransparentMesh: 1
+--- !u!224 &4063525522472893340
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6583274779330259306}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2783522140089132056}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 26, y: 1}
+  m_SizeDelta: {x: -68, y: -2}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &4145780020770534895
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3965959493576889886}
+  - component: {fileID: 7939808085556862266}
+  - component: {fileID: 9047323357875955615}
+  m_Layer: 0
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &4202238051429702858
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4712011790973011541}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4320443646223247469
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6398977344543177371}
+  - component: {fileID: 4024344592339294978}
+  - component: {fileID: 8115329578935181738}
+  m_Layer: 0
+  m_Name: DPS
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &4355589309260234648
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7228025569570312417}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.1, g: 0.12, b: 0.18, a: 0.85}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &4561446425211081313
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7560025136434969268}
+  m_CullTransparentMesh: 1
+--- !u!114 &4707420952442580982
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 738066628160136753}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 0.65, g: 0.85, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 12
+  m_fontSizeBase: 12
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 4096
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &4712011790973011541
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5115390148210650373}
+  - component: {fileID: 6055809561714352562}
+  - component: {fileID: 4202238051429702858}
+  m_Layer: 0
+  m_Name: Icon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4925533783310559235
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8747329268476968968}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7796576470580452198}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -4, y: -4}
+  m_SizeDelta: {x: 10, y: 10}
+  m_Pivot: {x: 1, y: 1}
+--- !u!224 &5046353410795562271
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5653184908642545304}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.85, y: 0.85, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2762031687140289538}
+  - {fileID: 6314286605817567001}
+  - {fileID: 6398977344543177371}
+  - {fileID: 7953424752355858042}
+  m_Father: {fileID: 1854075781}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 280, y: 56}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &5115390148210650373
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4712011790973011541}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2783522140089132056}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 4, y: 0}
+  m_SizeDelta: {x: 48, y: 48}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!114 &5502706630075364080
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6007800608388791921}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5653184908642545304
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5046353410795562271}
+  - component: {fileID: 3397880272575184201}
+  - component: {fileID: 1605839116365251041}
+  - component: {fileID: 5653184908642545305}
+  m_Layer: 0
+  m_Name: PowerUpSlot_0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &5653184908642545305
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5653184908642545304}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 458922bc0e7c35f4b8791dba10a681bc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.UI.HUD.PowerUpSlotUI
+  labelText: {fileID: 2100856366338156184}
+  statText: {fileID: 8115329578935181738}
+  rarityFrame: {fileID: 1605839116365251041}
+  elementFrame: {fileID: 5502706630075364080}
+  iconImage: {fileID: 6555103802014735821}
+--- !u!222 &5732663453887822926
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3376878023570796447}
+  m_CullTransparentMesh: 1
+--- !u!1 &6007800608388791921
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7953424752355858042}
+  - component: {fileID: 495510105796820298}
+  - component: {fileID: 5502706630075364080}
+  m_Layer: 0
+  m_Name: ElementFrame
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!222 &6055809561714352562
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4712011790973011541}
+  m_CullTransparentMesh: 1
+--- !u!222 &6300651355427805701
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6583274779330259306}
+  m_CullTransparentMesh: 1
+--- !u!224 &6314286605817567001
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6422684909970535656}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5046353410795562271}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 26, y: -1}
+  m_SizeDelta: {x: -68, y: -2}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &6398977344543177371
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4320443646223247469}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5046353410795562271}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 26, y: 1}
+  m_SizeDelta: {x: -68, y: -2}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &6422684909970535656
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6314286605817567001}
+  - component: {fileID: 1046783930022911037}
+  - component: {fileID: 2100856366338156184}
+  m_Layer: 0
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &6531431173564391379
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1283090308043363860}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 0.65, g: 0.85, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 12
+  m_fontSizeBase: 12
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 4096
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &6555103802014735821
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2435705026456864594}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6583274779330259306
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4063525522472893340}
+  - component: {fileID: 6300651355427805701}
+  - component: {fileID: 1168191876132020397}
+  m_Layer: 0
+  m_Name: DPS
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6893694395649660966
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7103463013140099117}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8629829940318579523}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -4, y: -4}
+  m_SizeDelta: {x: 10, y: 10}
+  m_Pivot: {x: 1, y: 1}
+--- !u!1 &7103463013140099117
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6893694395649660966}
+  - component: {fileID: 3975280973495825174}
+  - component: {fileID: 9049673035021352108}
+  m_Layer: 0
+  m_Name: ElementFrame
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &7228025569570312417
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7796576470580452198}
+  - component: {fileID: 368324677035590448}
+  - component: {fileID: 4355589309260234648}
+  - component: {fileID: 7796576470580452199}
+  m_Layer: 0
+  m_Name: PowerUpSlot_3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!222 &7370517664501660749
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3744408570819379062}
+  m_CullTransparentMesh: 1
+--- !u!114 &7378784926336093321
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8747329268476968968}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!224 &7380191553638603077
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7560025136434969268}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8629829940318579523}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 26, y: -1}
+  m_SizeDelta: {x: -68, y: -2}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &7560025136434969268
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7380191553638603077}
+  - component: {fileID: 4561446425211081313}
+  - component: {fileID: 3237193751889766596}
+  m_Layer: 0
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7567970242760045767
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 738066628160136753}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8629829940318579523}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 26, y: 1}
+  m_SizeDelta: {x: -68, y: -2}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &7724525510064231313
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1154667503615248654}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!224 &7796576470580452198
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7228025569570312417}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.85, y: 0.85, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 896087007851156091}
+  - {fileID: 9051080196489374048}
+  - {fileID: 8283954458591069410}
+  - {fileID: 4925533783310559235}
+  m_Father: {fileID: 1854075781}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 280, y: 56}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &7796576470580452199
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7228025569570312417}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 458922bc0e7c35f4b8791dba10a681bc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.UI.HUD.PowerUpSlotUI
+  labelText: {fileID: 3971192967513053409}
+  statText: {fileID: 6531431173564391379}
+  rarityFrame: {fileID: 4355589309260234648}
+  elementFrame: {fileID: 7378784926336093321}
+  iconImage: {fileID: 8125434223549457332}
+--- !u!222 &7939808085556862266
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4145780020770534895}
+  m_CullTransparentMesh: 1
+--- !u!224 &7953424752355858042
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6007800608388791921}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5046353410795562271}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -4, y: -4}
+  m_SizeDelta: {x: 10, y: 10}
+  m_Pivot: {x: 1, y: 1}
+--- !u!114 &8115329578935181738
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4320443646223247469}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 0.65, g: 0.85, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 12
+  m_fontSizeBase: 12
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 4096
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &8125434223549457332
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 861985901478770987}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!224 &8283954458591069410
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1283090308043363860}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7796576470580452198}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 26, y: 1}
+  m_SizeDelta: {x: -68, y: -2}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &8294164490411248273
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9051080196489374048}
+  - component: {fileID: 2647504417008083524}
+  - component: {fileID: 3971192967513053409}
+  m_Layer: 0
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &8565889613478920422
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3376878023570796447}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.1, g: 0.12, b: 0.18, a: 0.85}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &8565889613478920423
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3376878023570796447}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 458922bc0e7c35f4b8791dba10a681bc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.UI.HUD.PowerUpSlotUI
+  labelText: {fileID: 9047323357875955615}
+  statText: {fileID: 1168191876132020397}
+  rarityFrame: {fileID: 8565889613478920422}
+  elementFrame: {fileID: 3239420283717317623}
+  iconImage: {fileID: 4202238051429702858}
+--- !u!224 &8629829940318579523
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9205158162414969028}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.85, y: 0.85, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1702318897558610526}
+  - {fileID: 7380191553638603077}
+  - {fileID: 7567970242760045767}
+  - {fileID: 6893694395649660966}
+  m_Father: {fileID: 1854075781}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 280, y: 56}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &8747329268476968968
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4925533783310559235}
+  - component: {fileID: 3232274591354422067}
+  - component: {fileID: 7378784926336093321}
+  m_Layer: 0
+  m_Name: ElementFrame
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &9047323357875955615
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4145780020770534895}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\u2014"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 4096
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &9049673035021352108
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7103463013140099117}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!224 &9051080196489374048
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8294164490411248273}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7796576470580452198}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 26, y: -1}
+  m_SizeDelta: {x: -68, y: -2}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &9205158162414969028
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8629829940318579523}
+  - component: {fileID: 2228399122209207061}
+  - component: {fileID: 2846970955565371325}
+  - component: {fileID: 9205158162414969029}
+  m_Layer: 0
+  m_Name: PowerUpSlot_1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &9205158162414969029
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9205158162414969028}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 458922bc0e7c35f4b8791dba10a681bc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.UI.HUD.PowerUpSlotUI
+  labelText: {fileID: 3237193751889766596}
+  statText: {fileID: 4707420952442580982}
+  rarityFrame: {fileID: 2846970955565371325}
+  elementFrame: {fileID: 9049673035021352108}
+  iconImage: {fileID: 7724525510064231313}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/_CyberPickle/Scenes/Game/Game.unity
+++ b/Assets/_CyberPickle/Scenes/Game/Game.unity
@@ -152,11 +152,11 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1940658946}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 84.236046, y: 184.45001}
-  m_SizeDelta: {x: 31.5279, y: 31.1}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -4, y: -4}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 1, y: 1}
 --- !u!114 &14474311
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -283,6 +283,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 84723668}
+  - component: {fileID: 84723669}
   m_Layer: 0
   m_Name: CardSpawnContainer
   m_TagString: Untagged
@@ -301,14 +302,43 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 1940658946}
+  - {fileID: 1071791098}
+  - {fileID: 551597030}
   m_Father: {fileID: 1854075781}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 500, y: 200}
+  m_SizeDelta: {x: 1050, y: 240}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &84723669
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 84723667}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.HorizontalLayoutGroup
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 4
+  m_Spacing: 16
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 0
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
 --- !u!1 &136492084
 GameObject:
   m_ObjectHideFlags: 0
@@ -695,11 +725,11 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1071791098}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 84.236046, y: 184.45001}
-  m_SizeDelta: {x: 31.5279, y: 31.1}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -4, y: -4}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 1, y: 1}
 --- !u!114 &173131959
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -903,10 +933,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1940658946}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 143.9}
-  m_SizeDelta: {x: 200, y: 50}
+  m_AnchorMin: {x: 0, y: 0.78}
+  m_AnchorMax: {x: 1, y: 0.92}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -16, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &197486199
 MonoBehaviour:
@@ -955,8 +985,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 36
-  m_fontSizeBase: 36
+  m_fontSize: 14
+  m_fontSizeBase: 14
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -1044,7 +1074,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 300}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &207336861
 MonoBehaviour:
@@ -1725,10 +1755,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1071791098}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -129}
-  m_SizeDelta: {x: 200, y: 142}
+  m_AnchorMin: {x: 0, y: 0.1}
+  m_AnchorMax: {x: 1, y: 0.42}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -16, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &409085382
 MonoBehaviour:
@@ -1777,7 +1807,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 39.9
+  m_fontSize: 9
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -2260,10 +2290,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1071791098}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 143.9}
-  m_SizeDelta: {x: 200, y: 50}
+  m_AnchorMin: {x: 0, y: 0.78}
+  m_AnchorMax: {x: 1, y: 0.92}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -16, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &477250079
 MonoBehaviour:
@@ -2312,8 +2342,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 36
-  m_fontSizeBase: 36
+  m_fontSize: 14
+  m_fontSizeBase: 14
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -2443,7 +2473,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
   m_AnchoredPosition: {x: 0, y: 6}
-  m_SizeDelta: {x: 0, y: 14}
+  m_SizeDelta: {x: 0, y: 12}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!114 &496452543
 MonoBehaviour:
@@ -2533,22 +2563,22 @@ PrefabInstance:
     - target: {fileID: 2699190917507265892, guid: 166b5331cbeced34aa82a792c77e849a,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2699190917507265892, guid: 166b5331cbeced34aa82a792c77e849a,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2699190917507265892, guid: 166b5331cbeced34aa82a792c77e849a,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2699190917507265892, guid: 166b5331cbeced34aa82a792c77e849a,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2699190917507265892, guid: 166b5331cbeced34aa82a792c77e849a,
         type: 3}
@@ -2598,7 +2628,7 @@ PrefabInstance:
     - target: {fileID: 2699190917507265892, guid: 166b5331cbeced34aa82a792c77e849a,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: -380
       objectReference: {fileID: 0}
     - target: {fileID: 2699190917507265892, guid: 166b5331cbeced34aa82a792c77e849a,
         type: 3}
@@ -2691,12 +2721,12 @@ RectTransform:
   - {fileID: 1467550218}
   - {fileID: 2023258640}
   - {fileID: 796058609}
-  m_Father: {fileID: 1230510421}
+  m_Father: {fileID: 84723668}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 300, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 150, y: 220}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &551597031
 MonoBehaviour:
@@ -3344,22 +3374,22 @@ PrefabInstance:
     - target: {fileID: 2699190917507265892, guid: 166b5331cbeced34aa82a792c77e849a,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2699190917507265892, guid: 166b5331cbeced34aa82a792c77e849a,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2699190917507265892, guid: 166b5331cbeced34aa82a792c77e849a,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2699190917507265892, guid: 166b5331cbeced34aa82a792c77e849a,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2699190917507265892, guid: 166b5331cbeced34aa82a792c77e849a,
         type: 3}
@@ -3414,7 +3444,7 @@ PrefabInstance:
     - target: {fileID: 2699190917507265892, guid: 166b5331cbeced34aa82a792c77e849a,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -300
       objectReference: {fileID: 0}
     - target: {fileID: 2699190917507265892, guid: 166b5331cbeced34aa82a792c77e849a,
         type: 3}
@@ -3619,10 +3649,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 551597030}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 200, y: 400}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &722683951
 MonoBehaviour:
@@ -4107,7 +4137,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
   m_AnchoredPosition: {x: 0, y: 6}
-  m_SizeDelta: {x: 0, y: 14}
+  m_SizeDelta: {x: 0, y: 12}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!114 &796058610
 MonoBehaviour:
@@ -4288,10 +4318,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1940658946}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -59.2}
-  m_SizeDelta: {x: 200, y: 50}
+  m_AnchorMin: {x: 0, y: 0.43}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -0.0000019073486}
+  m_SizeDelta: {x: -16, y: 0.0000038146973}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &884267095
 MonoBehaviour:
@@ -4340,15 +4370,15 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 36
-  m_fontSizeBase: 36
+  m_fontSize: 10
+  m_fontSizeBase: 10
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_characterHorizontalScale: 1
@@ -4470,10 +4500,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1071791098}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 200, y: 400}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &908551422
 MonoBehaviour:
@@ -5173,10 +5203,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1071791098}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -59.2}
-  m_SizeDelta: {x: 200, y: 50}
+  m_AnchorMin: {x: 0, y: 0.43}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -0.0000019073486}
+  m_SizeDelta: {x: -16, y: 0.0000038146973}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1027135007
 MonoBehaviour:
@@ -5225,15 +5255,15 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 36
-  m_fontSizeBase: 36
+  m_fontSize: 10
+  m_fontSizeBase: 10
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_characterHorizontalScale: 1
@@ -5449,7 +5479,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
   m_AnchoredPosition: {x: 0, y: 6}
-  m_SizeDelta: {x: 0, y: 14}
+  m_SizeDelta: {x: 0, y: 12}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!114 &1062419999
 MonoBehaviour:
@@ -5515,12 +5545,12 @@ RectTransform:
   - {fileID: 207336860}
   - {fileID: 173131958}
   - {fileID: 1062419998}
-  m_Father: {fileID: 1230510421}
+  m_Father: {fileID: 84723668}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
+  m_SizeDelta: {x: 150, y: 220}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1071791099
 MonoBehaviour:
@@ -5589,10 +5619,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 551597030}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -129}
-  m_SizeDelta: {x: 200, y: 142}
+  m_AnchorMin: {x: 0, y: 0.1}
+  m_AnchorMax: {x: 1, y: 0.42}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -16, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1086944830
 MonoBehaviour:
@@ -5641,7 +5671,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 39.9
+  m_fontSize: 9
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -5785,9 +5815,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2136795665}
-  - {fileID: 1940658946}
-  - {fileID: 1071791098}
-  - {fileID: 551597030}
   - {fileID: 1282590689}
   - {fileID: 790489222}
   m_Father: {fileID: 1803396267}
@@ -6293,10 +6320,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1071791098}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 25}
-  m_SizeDelta: {x: 100, y: 100}
+  m_AnchorMin: {x: 0.25, y: 0.45}
+  m_AnchorMax: {x: 0.75, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1305791335
 MonoBehaviour:
@@ -6505,10 +6532,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 551597030}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -59.2}
-  m_SizeDelta: {x: 200, y: 50}
+  m_AnchorMin: {x: 0, y: 0.43}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -0.0000019073486}
+  m_SizeDelta: {x: -16, y: 0.0000038146973}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1450390654
 MonoBehaviour:
@@ -6557,15 +6584,15 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 36
-  m_fontSizeBase: 36
+  m_fontSize: 10
+  m_fontSizeBase: 10
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_characterHorizontalScale: 1
@@ -6646,7 +6673,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 300}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1467550219
 MonoBehaviour:
@@ -7139,7 +7166,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 300}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1627487759
 MonoBehaviour:
@@ -7255,10 +7282,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1940658946}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 25}
-  m_SizeDelta: {x: 100, y: 100}
+  m_AnchorMin: {x: 0.25, y: 0.45}
+  m_AnchorMax: {x: 0.75, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1633583128
 MonoBehaviour:
@@ -7420,10 +7447,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 551597030}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 25}
-  m_SizeDelta: {x: 100, y: 100}
+  m_AnchorMin: {x: 0.25, y: 0.45}
+  m_AnchorMax: {x: 0.75, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1678524422
 MonoBehaviour:
@@ -7701,22 +7728,22 @@ PrefabInstance:
     - target: {fileID: 2699190917507265892, guid: 166b5331cbeced34aa82a792c77e849a,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2699190917507265892, guid: 166b5331cbeced34aa82a792c77e849a,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2699190917507265892, guid: 166b5331cbeced34aa82a792c77e849a,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2699190917507265892, guid: 166b5331cbeced34aa82a792c77e849a,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2699190917507265892, guid: 166b5331cbeced34aa82a792c77e849a,
         type: 3}
@@ -7766,7 +7793,7 @@ PrefabInstance:
     - target: {fileID: 2699190917507265892, guid: 166b5331cbeced34aa82a792c77e849a,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 380
       objectReference: {fileID: 0}
     - target: {fileID: 2699190917507265892, guid: 166b5331cbeced34aa82a792c77e849a,
         type: 3}
@@ -8250,10 +8277,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1940658946}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -129}
-  m_SizeDelta: {x: 200, y: 142}
+  m_AnchorMin: {x: 0, y: 0.1}
+  m_AnchorMax: {x: 1, y: 0.42}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -16, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1839047033
 MonoBehaviour:
@@ -8302,7 +8329,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 39.9
+  m_fontSize: 9
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -8364,7 +8391,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1854075781}
-  - component: {fileID: 1854075783}
   - component: {fileID: 1854075782}
   - component: {fileID: 1854075784}
   m_Layer: 0
@@ -8399,8 +8425,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -360, y: -210}
-  m_SizeDelta: {x: 700, y: 600}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1100, y: 700}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1854075782
 MonoBehaviour:
@@ -8420,32 +8446,6 @@ MonoBehaviour:
   - {fileID: 620483737}
   - {fileID: 530800148}
   verbose: 0
---- !u!114 &1854075783
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1854075780}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.HorizontalLayoutGroup
-  m_Padding:
-    m_Left: 0
-    m_Right: 0
-    m_Top: 0
-    m_Bottom: 0
-  m_ChildAlignment: 4
-  m_Spacing: 8
-  m_ChildForceExpandWidth: 0
-  m_ChildForceExpandHeight: 0
-  m_ChildControlWidth: 0
-  m_ChildControlHeight: 0
-  m_ChildScaleWidth: 0
-  m_ChildScaleHeight: 0
-  m_ReverseArrangement: 0
 --- !u!114 &1854075784
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8472,8 +8472,8 @@ MonoBehaviour:
   powerUpSlotHighlights: []
   slotPickerEligibleColor: {r: 0.4, g: 0.95, b: 1, a: 0.6}
   rect: {fileID: 0}
-  compactPosition: {x: -360, y: -210}
-  compactScale: {x: 0.5, y: 0.5, z: 1}
+  compactPosition: {x: 700, y: 280}
+  compactScale: {x: 0.35, y: 0.35, z: 1}
   expandedPosition: {x: 0, y: 0}
   expandedScale: {x: 1, y: 1, z: 1}
   cardSpawnContainer: {fileID: 84723668}
@@ -8659,12 +8659,12 @@ RectTransform:
   - {fileID: 1627487758}
   - {fileID: 14474310}
   - {fileID: 496452542}
-  m_Father: {fileID: 1230510421}
+  m_Father: {fileID: 84723668}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -300, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 150, y: 220}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1940658947
 MonoBehaviour:
@@ -8733,10 +8733,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1940658946}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 200, y: 400}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1941604890
 MonoBehaviour:
@@ -9237,11 +9237,11 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 551597030}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 84.236046, y: 184.45001}
-  m_SizeDelta: {x: 31.5279, y: 31.1}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -4, y: -4}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 1, y: 1}
 --- !u!114 &2023258641
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -9752,22 +9752,22 @@ PrefabInstance:
     - target: {fileID: 2699190917507265892, guid: 166b5331cbeced34aa82a792c77e849a,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2699190917507265892, guid: 166b5331cbeced34aa82a792c77e849a,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2699190917507265892, guid: 166b5331cbeced34aa82a792c77e849a,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2699190917507265892, guid: 166b5331cbeced34aa82a792c77e849a,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 2699190917507265892, guid: 166b5331cbeced34aa82a792c77e849a,
         type: 3}
@@ -9822,7 +9822,7 @@ PrefabInstance:
     - target: {fileID: 2699190917507265892, guid: 166b5331cbeced34aa82a792c77e849a,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: 300
       objectReference: {fileID: 0}
     - target: {fileID: 2699190917507265892, guid: 166b5331cbeced34aa82a792c77e849a,
         type: 3}
@@ -9904,10 +9904,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 551597030}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 143.9}
-  m_SizeDelta: {x: 200, y: 50}
+  m_AnchorMin: {x: 0, y: 0.78}
+  m_AnchorMax: {x: 1, y: 0.92}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -16, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2067407914
 MonoBehaviour:
@@ -9956,8 +9956,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 36
-  m_fontSizeBase: 36
+  m_fontSize: 14
+  m_fontSizeBase: 14
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -10826,9 +10826,9 @@ RectTransform:
   - {fileID: 1065396803106903933}
   m_Father: {fileID: 1854075781}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -220}
   m_SizeDelta: {x: 280, y: 56}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2846970955565371325
@@ -11441,9 +11441,9 @@ RectTransform:
   - {fileID: 7953424752355858042}
   m_Father: {fileID: 1854075781}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 220}
   m_SizeDelta: {x: 280, y: 56}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &5115390148210650373
@@ -11967,9 +11967,9 @@ RectTransform:
   - {fileID: 4925533783310559235}
   m_Father: {fileID: 1854075781}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -160, y: 0}
   m_SizeDelta: {x: 280, y: 56}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &7796576470580452199
@@ -12240,9 +12240,9 @@ RectTransform:
   - {fileID: 6893694395649660966}
   m_Father: {fileID: 1854075781}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 160, y: 0}
   m_SizeDelta: {x: 280, y: 56}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &8747329268476968968


### PR DESCRIPTION
## Summary

Complete M8 milestone — element + power-up system end-to-end, including the cross HUD, loadout-aware draft, slot picker, banked rerolls, and commit animation. Five focused commits, ready to merge once the artist wires the new prefab fields.

### Commit chain

| # | SHA | Step |
|---|---|---|
| 1 | `3ba0a18` | Cross loadout + element-coupled power-ups (LoadoutAxis, PowerUpInstanceData, PowerUpData refactor) |
| 2 | `6770efb` | Loadout-aware card pool + skip→reroll bank + Luck draft size |
| 3 | `9ee1e7d` | Re-author existing PowerUp assets + 10 new card SOs in pool |
| 4 | `e46adbe` | Cross UI + slot-picker flow + Skip/Reroll buttons |
| 5 | `20e3d99` | DOTween animation + cards-in-center + stat pips + commit FX |

### What's new in step 5 (animation polish)

- **`LoadoutCrossPanel.SetState`** now tweens `anchoredPosition` + `localScale` via DOTween (0.45s, `Ease.OutBack`). Uses `SetUpdate(true)` so it animates during `LevelUpPaused` (`Time.timeScale = 0`). Tweens auto-killed on disable / destroy.
- **`PlayCommitAnimation(fromScreenPos, elementColor, pipCount)`** spawns element-tinted pip prefabs at the picked card's position and tweens them to the cross center with jitter + staggered launch — visual feedback that the modifiers were absorbed by the build.
- **`CardSlot` stat pips** — `statPipsContainer` + `statPipPrefab` fields; pip count = `(int)rolledRarity + 1` (Common=1 ... Legendary=5). Pips tinted by element if rolled, else by rarity. Designer anchors the container at the card's bottom edge per the "modifiers face the core" visual concept.
- **`LevelUpScreenController`** now triggers `crossPanel.SetState(Expanded)` on `OnCardsDrawn`, plays the commit animation before applying the picked card, then `SetState(Compact)` on commit / skip.

### Scene wiring needed (artist work)

After this PR merges, the artist needs to:

1. **Replace `WeaponSlotsPanel`** in the HUD with `LoadoutCrossPanel` (or add it to the same GameObject, disable the old script)
2. **Add 4 `PowerUpSlotUI` children** (clone WeaponSlot prefab, swap script) — wire to `powerUpSlots[0..3]`
3. **Lay out the cross**: 4 weapon cells + 4 power-up cells around a central area. Wire `cardSpawnContainer` to that center area
4. **Tune position/scale**: `compactPosition` / `compactScale` (in-game) and `expandedPosition` / `expandedScale` (modal)
5. **Pip prefabs**: small Image prefabs for `commitPipPrefab` (LoadoutCrossPanel) and `statPipPrefab` (CardSlot)
6. (Optional) **Skip / Reroll / Cancel buttons** on the level-up modal — wire the inspector slots on `LevelUpScreenController`

For testing right now: even without the cross-shaped layout, the system works — the panel just stays in the existing horizontal layout, the cross-state animation interpolates between two positions you set, and pip prefabs are no-ops if not assigned.

### Test plan

- [x] Compile clean
- [x] In-game: cross is in compact position, weapons + power-ups visible (power-ups empty until cards land)
- [x] Tooltips on every cell — same hover/lock behavior as M7.4 ✅
- [x] Level up: cross animates to expanded position, cards fade in
- [x] Pick a `NewPowerUp` card → cross enters slot-picker → click empty axis → power-up applied + element conferred to axis weapon
- [x] Watch the commit animation: pips fly from the picked card to cross center
- [ ] Skip → bank gains +1 reroll. Reroll → spends 1 bank, redraws same draft. Reroll button auto-disables when bank is 0
- [ ] Card pool is loadout-aware: NewWeapon disappears once weapon slots full; LevelUpWeapon only shows for equipped weapons

🤖 Generated with [Claude Code](https://claude.com/claude-code)