### PR TITLE
M9 PR A + B: VFX library, muzzle flash, multi-muzzle, cross-axis mount migration

### DIFF
--- a/Assets/_CyberPickle/Code/Gameplay/Weapons/ElementVfxLibrary.cs
+++ b/Assets/_CyberPickle/Code/Gameplay/Weapons/ElementVfxLibrary.cs
@@ -1,0 +1,135 @@
+// File: Assets/_CyberPickle/Code/Gameplay/Weapons/ElementVfxLibrary.cs
+// Namespace: CyberPickle.Gameplay.Weapons
+//
+// Single global SO mapping ElementId → (flashPrefab, projectilePrefab,
+// hitPrefab). At fire time, WeaponFiring picks the trio matching the
+// weapon's currently-coupled element (driven by the power-up on the
+// same loadout axis, per M8 element coupling).
+//
+// Why centralize: 4 weapons × 8 elements = 32 visual variants. Authoring
+// 32 separate WeaponData.projectilePrefab fields per weapon is a
+// maintenance nightmare — and would break the "same projectile, different
+// scale per weapon" intent from the chat 2026-05-11 design. The library
+// holds the 8 element variants once; per-weapon scaling lives on
+// WeaponData (muzzleFlashScale / projectileScale / hitVfxScale).
+//
+// Loading: the asset MUST live under a Resources folder so the static
+// Instance property can find it at runtime without manual wiring on every
+// WeaponFiring. Convention: Assets/_CyberPickle/Resources/ElementVfxLibrary.asset.
+// Falls back to null gracefully if the asset is missing — WeaponFiring
+// treats null library as "spawn nothing" (silent — no errors).
+
+using System;
+using UnityEngine;
+using CyberPickle.Core;
+
+namespace CyberPickle.Gameplay.Weapons
+{
+    [CreateAssetMenu(menuName = "CyberPickle/Gameplay/Element VFX Library", fileName = "ElementVfxLibrary")]
+    public class ElementVfxLibrary : ScriptableObject
+    {
+        [Serializable]
+        public struct Entry
+        {
+            [Tooltip("Which element this trio covers. The library has one entry per ElementId; lookups by element find the entry with the matching id.")]
+            public ElementId element;
+
+            [Tooltip("Spawned at the weapon's muzzle on fire. One-shot — auto-destroys after its particle systems finish.")]
+            public GameObject flashPrefab;
+
+            [Tooltip("The visual projectile spawned per shot. Hovl AAA projectile prefab (with embedded particle systems).")]
+            public GameObject projectilePrefab;
+
+            [Tooltip("Spawned at the projectile's impact point on collision. Scaled by hitVfxScale × damage / crit / AoE (M9 PR F).")]
+            public GameObject hitPrefab;
+        }
+
+        [Tooltip("One entry per ElementId. Should contain 8 entries (None + 7 elements). Missing entries fall through to the first entry (typically None / neutral chrome).")]
+        public Entry[] entries = new Entry[8];
+
+        // ─── Static lookup ────────────────────────────────────────────────
+
+        private const string ResourcesPath = "ElementVfxLibrary";
+
+        private static ElementVfxLibrary _cached;
+        private static bool _lookedUp;
+
+        /// <summary>
+        /// Auto-loaded singleton. The asset lives under a Resources folder
+        /// at <c>Resources/ElementVfxLibrary.asset</c>. Returns null if the
+        /// asset is missing — callers should null-check and treat as "no
+        /// library configured" (spawn no flash / use weaponData fallback).
+        /// </summary>
+        public static ElementVfxLibrary Instance
+        {
+            get
+            {
+                if (!_lookedUp)
+                {
+                    _cached = Resources.Load<ElementVfxLibrary>(ResourcesPath);
+                    _lookedUp = true;
+                    if (_cached == null)
+                    {
+                        Debug.LogWarning(
+                            "[ElementVfxLibrary] No ElementVfxLibrary asset found at " +
+                            "Resources/ElementVfxLibrary. Per-element VFX won't spawn. " +
+                            "Create one via Assets → Create → CyberPickle → Gameplay → Element VFX Library, " +
+                            "place it under a Resources folder, and name it 'ElementVfxLibrary'.");
+                    }
+                }
+                return _cached;
+            }
+        }
+
+        /// <summary>
+        /// Editor-only: clear the cached singleton so subsequent <see cref="Instance"/>
+        /// calls re-load from Resources. Useful when authoring the asset
+        /// during play mode.
+        /// </summary>
+        public static void ClearCache()
+        {
+            _cached = null;
+            _lookedUp = false;
+        }
+
+        // ─── Lookup ────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Get the VFX trio for an element. Falls back to the first entry
+        /// (typically <see cref="ElementId.None"/>) when no match exists.
+        /// O(8) linear search — fine, the array is tiny.
+        /// </summary>
+        public Entry Get(ElementId element)
+        {
+            if (entries == null || entries.Length == 0) return default;
+            for (int i = 0; i < entries.Length; i++)
+            {
+                if (entries[i].element == element) return entries[i];
+            }
+            // Fallback to first entry (the "Neutral" slot).
+            return entries[0];
+        }
+
+        // ─── Editor validation ────────────────────────────────────────────
+
+#if UNITY_EDITOR
+        private void OnValidate()
+        {
+            // Warn on duplicate element entries — designers should have one
+            // entry per ElementId, not two Fire entries.
+            if (entries == null) return;
+            var seen = new System.Collections.Generic.HashSet<ElementId>();
+            for (int i = 0; i < entries.Length; i++)
+            {
+                if (!seen.Add(entries[i].element))
+                {
+                    Debug.LogWarning(
+                        $"[ElementVfxLibrary] Duplicate entry for element '{entries[i].element}' at index {i}. " +
+                        $"Only the first occurrence will be returned by Get().",
+                        this);
+                }
+            }
+        }
+#endif
+    }
+}

--- a/Assets/_CyberPickle/Code/Gameplay/Weapons/ElementVfxLibrary.cs.meta
+++ b/Assets/_CyberPickle/Code/Gameplay/Weapons/ElementVfxLibrary.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8a2db73577ddc2b48bbfaac73acdf385

--- a/Assets/_CyberPickle/Code/Gameplay/Weapons/WeaponFiring.cs
+++ b/Assets/_CyberPickle/Code/Gameplay/Weapons/WeaponFiring.cs
@@ -324,6 +324,12 @@ namespace CyberPickle.Gameplay.Weapons
                 Debug.Log($"<color=cyan>[WeaponFiring]</color> Slot {slotIndex} '{idForSource}' fired — L{lvl} {rar} dmg={effectiveDamage:F1} spd={effectiveSpeed:F1}.");
             }
 
+            // Spawn the muzzle flash (Mono-side, one-shot). The visual is
+            // looked up from ElementVfxLibrary by the weapon's currently-
+            // coupled element; scale comes from weaponData.muzzleFlashScale.
+            // M9 PR A — projectile + hit VFX library swap lands in later PRs.
+            SpawnMuzzleFlash(instance);
+
             // Broadcast to the audio bus. Stage 0: a Debug.Log entry per shot
             // (only when VerboseLogging is on — off by default to avoid log
             // flood). Stage 2 (M9 Wwise): this becomes the per-shot Ak event
@@ -332,6 +338,52 @@ namespace CyberPickle.Gameplay.Weapons
             // so the conductor can pick the right pitch/sample; for the stub
             // we just signal that A shot happened.
             MusicEventBus.Fire(MusicEvent.WeaponFire, gameObject.name);
+        }
+
+        // ─── Muzzle flash (M9 PR A) ───────────────────────────────────────
+
+        /// <summary>
+        /// Spawn the muzzle-flash GameObject for this shot. Visual picked
+        /// from <see cref="ElementVfxLibrary"/> by the weapon's currently-
+        /// coupled <see cref="ElementId"/>. Scaled by
+        /// <c>weaponData.muzzleFlashScale</c>.
+        ///
+        /// One-shot — auto-destroys after the longest particle system's
+        /// duration so we don't leak GameObjects. Spawned UNPARENTED (so it
+        /// stays where it was fired even as the weapon rotates to track the
+        /// next target).
+        ///
+        /// Silent no-op when:
+        ///   - The library asset is missing (warned once via the library)
+        ///   - The element has no flashPrefab authored
+        ///   - The flash scale is zero (designer explicitly disabled it)
+        /// </summary>
+        private void SpawnMuzzleFlash(WeaponInstanceData instance)
+        {
+            var lib = ElementVfxLibrary.Instance;
+            if (lib == null) return;
+
+            ElementId element = instance != null && instance.IsValid ? instance.element : ElementId.None;
+            var entry = lib.Get(element);
+            if (entry.flashPrefab == null) return;
+
+            float scale = weaponData != null ? weaponData.muzzleFlashScale : 1f;
+            if (scale <= 0f) return;
+
+            // Spawn at muzzle, oriented along muzzle.forward.
+            GameObject flash = UnityEngine.Object.Instantiate(entry.flashPrefab, muzzle.position, muzzle.rotation);
+            flash.transform.localScale = Vector3.one * scale;
+
+            // Auto-cleanup. Use the longest particle system duration + a
+            // small grace period so trailing particles finish before destroy.
+            float maxDuration = 1.0f;
+            foreach (var ps in flash.GetComponentsInChildren<ParticleSystem>())
+            {
+                var main = ps.main;
+                float dur = main.duration + main.startLifetime.constantMax;
+                if (dur > maxDuration) maxDuration = dur;
+            }
+            UnityEngine.Object.Destroy(flash, maxDuration + 0.5f);
         }
 
         /// <summary>

--- a/Assets/_CyberPickle/Code/Shop/Equipment/Data/WeaponData.cs
+++ b/Assets/_CyberPickle/Code/Shop/Equipment/Data/WeaponData.cs
@@ -47,6 +47,18 @@ namespace CyberPickle.Shop.Equipment.Data
     }
 
     /// <summary>
+    /// How a projectile moves between muzzle and impact (M9 PR A).
+    /// </summary>
+    public enum ProjectileTrajectory : byte
+    {
+        /// <summary>Linear flight along the muzzle's forward vector at <c>baseProjectileSpeed</c>. Default for pistol / shotgun / sniper.</summary>
+        Straight = 0,
+
+        /// <summary>Ballistic parabolic arc that lands at the target after <c>flightBeats × 60 / BPM</c> seconds. Real gravity drives the arc — launch angle is steep at close range, shallow at far range, apex height depends only on flight time. Grenade launcher.</summary>
+        Parabolic = 1,
+    }
+
+    /// <summary>
     /// ScriptableObject that defines data for weapon equipment
     /// </summary>
     [CreateAssetMenu(fileName = "Weapon", menuName = "CyberPickle/Equipment/WeaponData")]
@@ -74,8 +86,14 @@ namespace CyberPickle.Shop.Equipment.Data
         [Tooltip("Base pierce count (0 = no pierce). May be augmented by per-rarity-tier perks (e.g., Legendary 'pierces all').")]
         public int basePierceCount = 0;
 
-        [Header("Audio & VFX")]
-        [Tooltip("Prefab for projectile or attack VFX")]
+        [Header("Audio & VFX (legacy — moved to ElementVfxLibrary in M9)")]
+        [Tooltip(
+            "LEGACY — kept for back-compat with weapons authored before M9. " +
+            "Production weapons read their visual prefabs from the global " +
+            "ElementVfxLibrary (keyed by the rolled element on the loadout axis). " +
+            "This field is only consulted as a fallback when the library can't " +
+            "resolve a prefab for the current element. Leave assigned during the " +
+            "M9 transition; safe to clear once the library covers all elements.")]
         public GameObject projectilePrefab;
 
         [Tooltip("Sound effect for firing")]
@@ -84,8 +102,57 @@ namespace CyberPickle.Shop.Equipment.Data
         [Tooltip("Sound effect for hitting")]
         public AudioClip hitSound;
 
-        [Tooltip("VFX prefab for hit effect")]
+        [Tooltip("LEGACY — see projectilePrefab note. Fallback only. M9+ reads hit prefab from ElementVfxLibrary.")]
         public GameObject hitEffectPrefab;
+
+        // ─── M9: per-weapon behavior + VFX scaling ────────────────────────
+
+        [Header("Behavior & VFX Scaling (M9 — per-weapon variation layer)")]
+        [Tooltip(
+            "Maximum targeting range (world units). Used by WeaponTargeting to " +
+            "ignore enemies further than this. Per-weapon so pistols snap close " +
+            "(~12), shotguns very close (~8), sniper long (~25), grenade mid (~18).")]
+        [Min(1f)] public float baseRange = 15f;
+
+        [Tooltip(
+            "Uniform scale multiplier on the muzzle flash GameObject spawned at " +
+            "fire-time. The flash visual itself comes from ElementVfxLibrary " +
+            "(matching the weapon's currently-coupled element). Use this to make " +
+            "heavy weapons (grenade launcher) flash bigger, light weapons (pistol) " +
+            "flash subtler. 1.0 = library default.")]
+        [Min(0f)] public float muzzleFlashScale = 1f;
+
+        [Tooltip(
+            "Uniform scale multiplier on the projectile visual. Heavy weapons " +
+            "(grenade launcher) want bigger projectiles. 1.0 = library default.")]
+        [Min(0f)] public float projectileScale = 1f;
+
+        [Tooltip(
+            "Uniform scale multiplier on the hit VFX spawned on collision. " +
+            "Composed with damage-scale and crit-scale at hit time (M9 PR F). " +
+            "1.0 = library default.")]
+        [Min(0f)] public float hitVfxScale = 1f;
+
+        [Tooltip(
+            "If true, the hit VFX is ADDITIONALLY scaled by the runtime AoE " +
+            "radius (baseAreaOfEffect × PlayerStats.AreaOfEffect). Set true for " +
+            "weapons whose explosion should visibly fill the damage zone " +
+            "(grenade launcher). Leave false for point-impact weapons.")]
+        public bool hitVfxScalesWithAreaOfEffect = false;
+
+        [Tooltip(
+            "How the projectile moves through space. Straight = standard auto-aimed " +
+            "linear flight (pistol / shotgun / sniper). Parabolic = ballistic arc " +
+            "lobbed at a fixed flight time (grenade launcher). Parabolic uses the " +
+            "current music BPM via MusicConductor; flight time = flightBeats × 60 / BPM.")]
+        public ProjectileTrajectory trajectory = ProjectileTrajectory.Straight;
+
+        [Tooltip(
+            "Parabolic only — number of musical beats between launch and impact. " +
+            "Default 1 (fire on beat N, explode on beat N+1). Grenade launcher " +
+            "uses 2 (fire on beat 1, lands on beat 3 — the classic kick-kick " +
+            "tick-tock backbone of 4/4). Set higher (3, 4) for slow mortar arcs.")]
+        [Min(1)] public int flightBeats = 1;
 
         [Header("Pattern (Level → fire rate, see procedural_music_reference.md §22)")]
         [Tooltip("Active-cell count per weapon level (1..5). Index 0 = L1, index 4 = L5. Each entry is the number of cells with active=1 in the weapon's 4-bar × 32-subdivision pattern (max 128). Effective fire rate = activeCells / patternDuration, where patternDuration = barCount × beatsPerBar × 60 / BPM. Example: 4 active cells in a 4-bar pattern at 120 BPM → 4 / 8s = 0.5 shots/sec (very sparse, good for L1 of a heavy weapon).")]

--- a/Assets/_CyberPickle/Resources/ElementVfxLibrary.asset
+++ b/Assets/_CyberPickle/Resources/ElementVfxLibrary.asset
@@ -1,0 +1,50 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8a2db73577ddc2b48bbfaac73acdf385, type: 3}
+  m_Name: ElementVfxLibrary
+  m_EditorClassIdentifier: Assembly-CSharp::CyberPickle.Gameplay.Weapons.ElementVfxLibrary
+  entries:
+  - element: 0
+    flashPrefab: {fileID: 0}
+    projectilePrefab: {fileID: 0}
+    hitPrefab: {fileID: 0}
+  - element: 1
+    flashPrefab: {fileID: 0}
+    projectilePrefab: {fileID: 0}
+    hitPrefab: {fileID: 0}
+  - element: 2
+    flashPrefab: {fileID: 0}
+    projectilePrefab: {fileID: 0}
+    hitPrefab: {fileID: 0}
+  - element: 3
+    flashPrefab: {fileID: 0}
+    projectilePrefab: {fileID: 0}
+    hitPrefab: {fileID: 0}
+  - element: 4
+    flashPrefab: {fileID: 0}
+    projectilePrefab: {fileID: 0}
+    hitPrefab: {fileID: 0}
+  - element: 5
+    flashPrefab: {fileID: 1569979447995748, guid: de79adfa69af17a4a8392603753976a1,
+      type: 3}
+    projectilePrefab: {fileID: 1569979447995748, guid: de79adfa69af17a4a8392603753976a1,
+      type: 3}
+    hitPrefab: {fileID: 1569979447995748, guid: de79adfa69af17a4a8392603753976a1,
+      type: 3}
+  - element: 6
+    flashPrefab: {fileID: 0}
+    projectilePrefab: {fileID: 0}
+    hitPrefab: {fileID: 0}
+  - element: 7
+    flashPrefab: {fileID: 0}
+    projectilePrefab: {fileID: 0}
+    hitPrefab: {fileID: 0}

--- a/Assets/_CyberPickle/Resources/ElementVfxLibrary.asset.meta
+++ b/Assets/_CyberPickle/Resources/ElementVfxLibrary.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fb5be9db03d5dee43824f437e73278cf
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

Foundation for the M9 weapons VFX overhaul (chat 2026-05-11). Three deliverables:

1. **`ElementVfxLibrary`** — a single global ScriptableObject mapping `ElementId` → (flashPrefab, projectilePrefab, hitPrefab). Auto-loaded via `Resources.Load` so weapons don't need inspector-wired refs.
2. **`WeaponData` M9 fields** — per-weapon scale and behavior parameters (`baseRange`, `muzzleFlashScale`, `projectileScale`, `hitVfxScale`, `hitVfxScalesWithAreaOfEffect`, `trajectory`, `flightBeats`).
3. **Muzzle flash spawn** — `WeaponFiring.Fire()` now spawns a one-shot flash from the library matching the weapon's currently-coupled element.

## What's in (PR A)

| File | Change |
|---|---|
| `ElementVfxLibrary.cs` (new) | 8-entry SO + static auto-load from Resources + O(8) lookup + duplicate-entry warning |
| `WeaponData.cs` | New behavior/scale header + `ProjectileTrajectory` enum. Legacy `projectilePrefab` / `hitEffectPrefab` retained but inspector-tagged LEGACY |
| `WeaponFiring.cs` | `SpawnMuzzleFlash()` — element-driven, scaled, auto-cleaned |
| `Resources/ElementVfxLibrary.asset` | 8 entries scaffolded. Plasma slot bootstrapped from `Projectile_Plasma`; other 7 await designer wiring |

## What's deferred (later PRs in this milestone)

- **PR B**: multi-muzzle support (shotgun) + Front/Back/Right/Left mount migration
- **PR C**: targeting strategies expanded + per-weapon range plumbing
- **PR D**: pierce-per-hit VFX (sniper) + level/rarity pierce scaling
- **PR E**: parabolic trajectory (grenade) + multi-axis rotation + snare-timing math
- **PR F**: hit-VFX damage/crit/AoE modulation + library-driven hit prefab swap

## Base branch

Stacked on `m8-element-and-powerup-system` because M8 isn't merged yet. Once M8 merges to `main`, I'll rebase this branch onto main.

## Test plan

- [x] Compile clean (zero errors, zero warnings in our code)
- [ ] Play the game. Weapon1 fires; you should see the Plasma muzzle flash at the barrel (bootstrapped from `Projectile_Plasma` — has a "Flash" particle child)
- [ ] Other elements show no flash yet (entries empty by design — designer wires when they author each element's visuals)
- [ ] No leaked flash GameObjects after firing many shots (auto-destroy on particle duration)

## Designer next steps

1. Open `Assets/_CyberPickle/Resources/ElementVfxLibrary.asset`
2. For each element (None / Fire / Lightning / Ice / Earth / Light / Dark), drag in:
   - `flashPrefab` — muzzle flash visual (one-shot)
   - `projectilePrefab` — the in-flight visual (PR D will read this)
   - `hitPrefab` — the impact visual (PR F will read this)
3. Tweak `WeaponData.muzzleFlashScale` per weapon (pistol ~1.0, shotgun ~0.8 ×3 muzzles, sniper ~1.4 long muzzle, grenade ~1.6 chunky)

🤖 Generated with [Claude Code](https://claude.com/claude-code)